### PR TITLE
Add workflows to create tags and releases

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -1,0 +1,90 @@
+name: "Create Release"
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build_release:
+    name: "Build release"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+    steps:
+      - name: "[${{ runner.os }}] Checkout sources"
+        uses: actions/checkout@v2
+      - name: "[${{ runner.os }}] Cache dependencies"
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle
+            ${GITHUB_WORKSPACE}/.gradle
+          key: ${{ matrix.os }}-gitlab-clone-release
+      - name: "[${{ runner.os }}] Install GraalVM"
+        uses: DeLaGuardo/setup-graalvm@4.0
+        with:
+          graalvm: '21.1.0'
+          java: 'java11'
+          arch: 'amd64'
+      - name: "[${{ runner.os }}] Install native-image"
+        run: |
+          gu install native-image
+      - name: "[${{ runner.os }}] Setup SSH"
+        run: |
+          mkdir ~/.ssh
+          echo "${SSH_KNOWN_HOSTS}" > ~/.ssh/known_hosts
+          echo "${SSH_PRIVATE_KEY}" > ~/.ssh/id_rsa
+          chmod 500 ~/.ssh
+          chmod 400 ~/.ssh/*
+        env:
+          SSH_KNOWN_HOSTS: ${{ secrets.SSH_KNOWN_HOSTS }}
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      - name: "[${{ runner.os }}] Gradle build"
+        run: ./gradlew build nativeImage
+        env:
+          GITLAB_PRIVATE_TOKEN: ${{ secrets.GITLAB_PRIVATE_TOKEN }}
+      - name: "[${{ runner.os }}] Rename binaries"
+        run: |
+          version=${tag_ref/refs\/tags\//}
+          cp build/native-image/application ./gitlab-clone-${version}-${build_os}
+        env:
+          tag_ref: ${{ github.ref }}
+          build_os: ${{ runner.os }}
+      - name: "[${{ runner.os }}] Clean up"
+        run: sudo rm -rf ~/.ssh
+      - name: '[${{ runner.os }}] Upload artifacts'
+        uses: actions/upload-artifact@v2
+        with:
+          name: native-image-${{ runner.os }}
+          path: ./gitlab-clone-*
+          if-no-files-found: error
+
+  create_release:
+    name: "Create release"
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Download all workflow run artifacts'
+        uses: actions/download-artifact@v2
+        with:
+          path: 'artifacts'
+      - name: "Generate changelog"
+        id: changelog
+        uses: metcalfc/changelog-generator@v0.4.4
+        with:
+          myToken: ${{ secrets.GITHUB_TOKEN }}
+      - name: "Create Release"
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body: ${{ steps.changelog.outputs.changelog }}
+          draft: false
+          prerelease: false
+          files: |
+            artifacts/git-clone-*

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -18,7 +18,7 @@ jobs:
           path: |
             ~/.gradle
             ${GITHUB_WORKSPACE}/.gradle
-          key: ${{ runner.os }}-gitlab-clone
+          key: ${{ runner.os }}-gitlab-clone-development
       - name: "Install GraalVM"
         uses: DeLaGuardo/setup-graalvm@4.0
         with:

--- a/.github/workflows/git-tag.yaml
+++ b/.github/workflows/git-tag.yaml
@@ -1,0 +1,61 @@
+###############################################################################
+# Workflow runs on commits pushed to develop branch, and creates git tags
+#
+# When new commits are pushed to develop, this workflow:
+# - checks for module images tagged with the sha of the last commit in the set
+# - if all modules can be found, the a new git tag is created
+###############################################################################
+name: "Tag git"
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  tag:
+    name: "Create git tag"
+    runs-on: ubuntu-latest
+    env:
+      tooling_dir: ${{ github.workspace }}/../tooling
+    steps:
+      - name: "Cache tooling"
+        uses: actions/cache@v2
+        with:
+          path: ${tooling_dir}
+          key: ${{ runner.os }}-gitlab-clone-git-tag
+      - name: "Setup tools"
+        run: |
+          mkdir -p ${tooling_dir}
+          cd ${tooling_dir}
+          wget --no-clobber https://github.com/miguelaferreira/semver_bash/archive/master.zip
+          unzip master.zip
+          cd semver_bash-master
+          sudo mv semver.sh bump.sh /bin
+          sudo chmod +x /bin/bump.sh
+      - name: "Checkout sources"
+        uses: actions/checkout@v2
+      - name: "Bump version number"
+        id: bump
+        run: |
+          version="$(cat ${version_file})"
+          bump.sh "${old_version}" > ${version_file}
+          echo "::set-output name=version-file::${version_file}"
+          echo "::set-output name=version::${version}"
+          echo "::set-output name=new-version::$(cat ${version_file})"
+        env:
+          version_file: VERSION
+      - name: "Create tag"
+        uses: EndBug/add-and-commit@v7.0.0
+        with:
+          message: "Increment version from '${{ steps.bump.outputs.version }}' to '${{ steps.bump.outputs.new-version }}'"
+          default_author: github_actions
+          tag: "${{ steps.bump.outputs.version }}"
+          push: true
+      - name: "Create bump commit"
+        uses: EndBug/add-and-commit@v7.0.0
+        with:
+          message: "Increment version from '${{ steps.bump.outputs.version }}' to '${{ steps.bump.outputs.new-version }}'"
+          add: ${{ steps.bump.outputs.version-file }}
+          default_author: github_actions
+          push: true

--- a/.github/workflows/git-tag.yaml
+++ b/.github/workflows/git-tag.yaml
@@ -1,10 +1,3 @@
-###############################################################################
-# Workflow runs on commits pushed to develop branch, and creates git tags
-#
-# When new commits are pushed to develop, this workflow:
-# - checks for module images tagged with the sha of the last commit in the set
-# - if all modules can be found, the a new git tag is created
-###############################################################################
 name: "Tag git"
 
 on:


### PR DESCRIPTION
This PR adds two workflows, one to create git tags push to `main` branch and the other to create releases on new tags.