### PR TITLE
Fix sub group fetching

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -71,6 +71,7 @@ jobs:
           cd ../release
           for file in *; do sha256sum "${file}" > "${file}.sha256sum"; done
           tar czf all-files.tar.gz *
+          sha256sum all-files.tar.gz > all-files.tar.gz.sha256sum
       - name: "Generate changelog"
         id: changelog
         uses: metcalfc/changelog-generator@v0.4.4

--- a/src/main/java/gitlab/clone/CloningService.java
+++ b/src/main/java/gitlab/clone/CloningService.java
@@ -54,6 +54,7 @@ public class CloningService {
         final CloneCommand cloneCommand = Git.cloneRepository();
         cloneCommand.setURI(project.getSshUrlToRepo());
         cloneCommand.setDirectory(new File(pathToClone));
+        cloneCommand.setCloneSubmodules(true);
         cloneCommand.setTransportConfigCallback(transport -> {
             SshTransport sshTransport = (SshTransport) transport;
             sshTransport.setSshSessionFactory(sshSessionFactory);

--- a/src/main/java/gitlab/clone/GitlabClient.java
+++ b/src/main/java/gitlab/clone/GitlabClient.java
@@ -14,8 +14,14 @@ public interface GitlabClient {
     @Get("/groups{?search,per_page}")
     Flowable<GitlabGroup> searchGroups(@Header(H_PRIVATE_TOKEN) String privateToken, @QueryValue String search, @QueryValue(value = "per_page") int perPage);
 
-    @Get("/groups/{id}/descendant_groups")
-    Flowable<GitlabGroup> groupDescendants(@Header(H_PRIVATE_TOKEN) String privateToken, @PathVariable String id);
+    @Get("/groups/{id}/descendant_groups{?all_available,per_page,page}")
+    Flowable<GitlabGroup> groupDescendants(
+            @Header(H_PRIVATE_TOKEN) String privateToken,
+            @PathVariable String id,
+            @QueryValue(value = "all_available") boolean allAvailable,
+            @QueryValue(value = "per_page") int perPage,
+            @QueryValue int page
+    );
 
     @Get("/groups/{id}/projects")
     Flowable<GitlabProject> groupProjects(@Header(H_PRIVATE_TOKEN) String privateToken, @PathVariable String id);

--- a/src/main/java/gitlab/clone/GitlabGroup.java
+++ b/src/main/java/gitlab/clone/GitlabGroup.java
@@ -1,11 +1,14 @@
 package gitlab.clone;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class GitlabGroup {
     private String id;
     private String name;
     private String path;
+    @JsonProperty("full_path")
+    String fullPath;
 
     @JsonCreator
     public GitlabGroup() {
@@ -33,5 +36,13 @@ public class GitlabGroup {
 
     public void setPath(String path) {
         this.path = path;
+    }
+
+    public String getFullPath() {
+        return fullPath;
+    }
+
+    public void setFullPath(String fullPath) {
+        this.fullPath = fullPath;
     }
 }

--- a/src/main/java/gitlab/clone/GitlabService.java
+++ b/src/main/java/gitlab/clone/GitlabService.java
@@ -1,12 +1,15 @@
 package gitlab.clone;
 
 import io.reactivex.Flowable;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.inject.Singleton;
 
+@Slf4j
 @Singleton
 public class GitlabService {
 
+    public static final int MAX_GROUPS_PER_PAGE = 100;
     private final GitlabClient client;
 
     public GitlabService(GitlabClient client) {
@@ -14,7 +17,7 @@ public class GitlabService {
     }
 
     public Flowable<GitlabGroup> searchGroups(String privateToken, String search, boolean onlyNameMatches) {
-        final Flowable<GitlabGroup> gitlabGroupFlowable = client.searchGroups(privateToken, search, 1000);
+        final Flowable<GitlabGroup> gitlabGroupFlowable = client.searchGroups(privateToken, search, MAX_GROUPS_PER_PAGE);
         if (onlyNameMatches) {
             return gitlabGroupFlowable.filter(gitlabGroup -> gitlabGroup.getName().equalsIgnoreCase(search));
         } else {
@@ -24,17 +27,31 @@ public class GitlabService {
 
     public Flowable<GitlabProject> getGitlabGroupProjects(String privateToken, GitlabGroup group) {
         final String groupId = group.getId();
+        log.trace("Searching in group {}", group.getFullPath());
         Flowable<GitlabProject> projects = getGroupProjects(privateToken, groupId);
-        Flowable<GitlabGroup> groups = getSubGroups(privateToken, groupId);
+        Flowable<GitlabGroup> subGroups = getSubGroups(privateToken, groupId);
 
-        return Flowable.concat(projects, groups.flatMap(subGroup -> getGitlabGroupProjects(privateToken, subGroup)));
+        return Flowable.concat(projects, subGroups.flatMap(subGroup -> getGroupProjects(privateToken, subGroup.getId())));
     }
 
     private Flowable<GitlabGroup> getSubGroups(String privateToken, String groupId) {
-        return client.groupDescendants(privateToken, groupId);
+        return getSubGroups(privateToken, groupId, 0);
+    }
+
+    private Flowable<GitlabGroup> getSubGroups(String privateToken, String groupId, int page) {
+        log.trace("Looking for subgroups at page {}", page);
+        final Flowable<GitlabGroup> groups = client.groupDescendants(privateToken, groupId, true, MAX_GROUPS_PER_PAGE, page);
+        return Flowable.concat(groups, groups.isEmpty()
+                                             .toFlowable()
+                                             .flatMap(isEmpty -> isEmpty ? Flowable.empty() : getSubGroups(privateToken, groupId, page + 1)));
+    }
+
+    private GitlabProject logProject(GitlabProject project) {
+        log.trace("Found project {}", project.getPathWithNamespace());
+        return project;
     }
 
     private Flowable<GitlabProject> getGroupProjects(String privateToken, String groupId) {
-        return client.groupProjects(privateToken, groupId);
+        return client.groupProjects(privateToken, groupId).map(this::logProject);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,6 @@ micronaut:
   application:
     name: gitlab-clone
 
-loggers:
-  level:
+logger:
+  levels:
     gitlab.clone: info

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 micronaut:
   application:
-    name: gitlabClone
+    name: gitlab-clone
 
 loggers:
   level:

--- a/src/test/java/gitlab/clone/GitlabClientTest.java
+++ b/src/test/java/gitlab/clone/GitlabClientTest.java
@@ -27,7 +27,7 @@ class GitlabClientTest {
 
     @Test
     void groupDescendants() {
-        final Flowable<GitlabGroup> groups = client.groupDescendants(gitlabPrivateToken, "11961707");
+        final Flowable<GitlabGroup> groups = client.groupDescendants(gitlabPrivateToken, "11961707", true, 100, 0);
 
         assertThat(groups.blockingIterable()).hasSize(3);
     }

--- a/src/test/java/gitlab/clone/GitlabServiceTest.java
+++ b/src/test/java/gitlab/clone/GitlabServiceTest.java
@@ -33,6 +33,6 @@ class GitlabServiceTest {
         final GitlabGroup group = service.searchGroups(gitlabPrivateToken, GITLAB_GROUP, true).blockingFirst();
         final Flowable<GitlabProject> projects = service.getGitlabGroupProjects(gitlabPrivateToken, group);
 
-        assertThat(projects.blockingIterable()).hasSize(4);
+        assertThat(projects.blockingIterable()).hasSize(5);
     }
 }


### PR DESCRIPTION
This PR fixes the fetching of gitlab sub groups by leveraging the pagination features of the underlying API. It also configures the cloning service to initialise project sub-modules.