### PR TITLE
Refactor usage and add more logging options

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: "[${{ runner.os }}] Gradle build"
         run: ./gradlew build nativeImage
         env:
-          GITLAB_PRIVATE_TOKEN: ${{ secrets.GITLAB_PRIVATE_TOKEN }}
+          GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
       - name: "[${{ runner.os }}] Clean up"
         run: sudo rm -rf ~/.ssh
       - name: '[${{ runner.os }}] Upload artifacts'

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -45,7 +45,7 @@ jobs:
       - name: "Gradle build"
         run: ./gradlew build nativeImage
         env:
-          GITLAB_PRIVATE_TOKEN: ${{ secrets.GITLAB_PRIVATE_TOKEN }}
+          GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
       - name: "Run native image"
         run: build/native-image/application
       - name: "Clean up"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,11 @@ That is what this tool does.
 
 The `gitlab-clone` tool is built for two operating systems Linux and macOS.
 Each release on this repository provides binaries for these two operating systems.
-To install the tool, download the binary from the latest release, make it executable and place it on a reachable path.
+To install the tool, either download the binary from the latest release, make it executable and place it on a reachable path;
+or use `brew`.
+```bash
+brew install miguelaferreira/tools/git-clone
+```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -23,13 +23,22 @@ brew install miguelaferreira/tools/git-clone
 
 ## Usage
 
+Both the gitlab url (`GITLAB_URL`) and the private token (`GITLAB_TOKEN`) for accessing GitLab API are read from the environment.
+The GitLab url defaults to [https://gitlab.com](https://gitlab.com) when not defined in the environment.
+For cloning public groups the token needs `read_api` scope and for private groups it needs the `api` scope.
+See GitLab's [Limiting scopes of a personal access token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#limiting-scopes-of-a-personal-access-token)
+for more details on token scopes.
+
 ```bash
 $ GITLAB_TOKEN="..." gitlab-clone -h
-Usage: gitlab-clone [-hvV] GROUP PATH
-A tool to clone an entire GitLab group with all sub-groups and repositories.
-      GROUP       The GitLab group to clone.
-      PATH        The local path where to create the group clone.
-  -h, --help      Show this help message and exit.
-  -v, --verbose   Print out extra information about what the tool is doing.
-  -V, --version   Print version information and exit.
+Usage: gitlab-clone [-hvVx] [--debug] [--trace] GROUP PATH
+Clone an entire GitLab group with all sub-groups and repositories.
+      GROUP            The GitLab group to clone.
+      PATH             The local path where to create the group clone.
+  -h, --help           Show this help message and exit.
+  -V, --version        Print version information and exit.
+  -v, --verbose        Print out extra information about what the tool is doing.
+  -x, --very-verbose   Print out even more information about what the tool is doing.
+      --debug          Sets all loggers to DEBUG level.
+      --trace          Sets all loggers to TRACE level.
 ```

--- a/README.md
+++ b/README.md
@@ -24,14 +24,12 @@ brew install miguelaferreira/tools/git-clone
 ## Usage
 
 ```bash
-$ gitlab-clone -h
-Usage: gitlab-clone [-hvV] -g=GROUP [-p=PATH] -t=TOKEN
+$ GITLAB_TOKEN="..." gitlab-clone -h
+Usage: gitlab-clone [-hvV] GROUP PATH
 A tool to clone an entire GitLab group with all sub-groups and repositories.
-  -g, --group=GROUP   The GitLab group.
-  -h, --help          Show this help message and exit.
-  -p, --path=PATH     The local path where to create the group clone.
-                        Default: .
-  -t, --token=TOKEN   The GitLab private token.
-  -v, --verbose       Print out extra information about what the tool is doing.
-  -V, --version       Print version information and exit.
+      GROUP       The GitLab group to clone.
+      PATH        The local path where to create the group clone.
+  -h, --help      Show this help message and exit.
+  -v, --verbose   Print out extra information about what the tool is doing.
+  -V, --version   Print version information and exit.
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -52,5 +52,5 @@ java {
 }
 
 test {
-    environment "GITLAB_PRIVATE_TOKEN", System.getenv('GITLAB_PRIVATE_TOKEN')
+    environment "GITLAB_TOKEN", System.getenv('GITLAB_TOKEN')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -54,3 +54,7 @@ java {
 test {
     environment "GITLAB_TOKEN", System.getenv('GITLAB_TOKEN')
 }
+
+processResources {
+    from("VERSION")
+}

--- a/src/main/java/gitlab/clone/GitlabClient.java
+++ b/src/main/java/gitlab/clone/GitlabClient.java
@@ -7,16 +7,18 @@ import io.micronaut.http.annotation.QueryValue;
 import io.micronaut.http.client.annotation.Client;
 import io.reactivex.Flowable;
 
+import static gitlab.clone.GitlabClient.H_PRIVATE_TOKEN;
+
 @Client("${gitlab.url}/api/v4")
+@Header(name = H_PRIVATE_TOKEN, value = "${GITLAB_TOKEN}")
 public interface GitlabClient {
     String H_PRIVATE_TOKEN = "PRIVATE-TOKEN";
 
     @Get("/groups{?search,per_page}")
-    Flowable<GitlabGroup> searchGroups(@Header(H_PRIVATE_TOKEN) String privateToken, @QueryValue String search, @QueryValue(value = "per_page") int perPage);
+    Flowable<GitlabGroup> searchGroups(@QueryValue String search, @QueryValue(value = "per_page") int perPage);
 
     @Get("/groups/{id}/descendant_groups{?all_available,per_page,page}")
     Flowable<GitlabGroup> groupDescendants(
-            @Header(H_PRIVATE_TOKEN) String privateToken,
             @PathVariable String id,
             @QueryValue(value = "all_available") boolean allAvailable,
             @QueryValue(value = "per_page") int perPage,
@@ -24,5 +26,5 @@ public interface GitlabClient {
     );
 
     @Get("/groups/{id}/projects")
-    Flowable<GitlabProject> groupProjects(@Header(H_PRIVATE_TOKEN) String privateToken, @PathVariable String id);
+    Flowable<GitlabProject> groupProjects(@PathVariable String id);
 }

--- a/src/main/java/gitlab/clone/GitlabClient.java
+++ b/src/main/java/gitlab/clone/GitlabClient.java
@@ -7,7 +7,7 @@ import io.micronaut.http.annotation.QueryValue;
 import io.micronaut.http.client.annotation.Client;
 import io.reactivex.Flowable;
 
-@Client("https://gitlab.com/api/v4")
+@Client("${gitlab.url}/api/v4")
 public interface GitlabClient {
     String H_PRIVATE_TOKEN = "PRIVATE-TOKEN";
 

--- a/src/main/java/gitlab/clone/GitlabCloneCommand.java
+++ b/src/main/java/gitlab/clone/GitlabCloneCommand.java
@@ -50,7 +50,7 @@ public class GitlabCloneCommand implements Runnable {
     @Option(
             order = 3,
             names = {"--trace"},
-            description = "Sets all loggers to TRACE level."
+            description = "Sets all loggers to TRACE level. WARNING: this setting will leak the GitLab token to the logs, use with caution."
     )
     private boolean trace;
 

--- a/src/main/java/gitlab/clone/GitlabCloneCommand.java
+++ b/src/main/java/gitlab/clone/GitlabCloneCommand.java
@@ -18,22 +18,40 @@ import java.nio.file.Paths;
 @Slf4j
 @Command(
         name = "gitlab-clone",
-        description = "A tool to clone an entire GitLab group with all sub-groups and repositories.",
+        description = "Clone an entire GitLab group with all sub-groups and repositories.",
         mixinStandardHelpOptions = true,
-        versionProvider = GitlabCloneCommand.AppVersionProvider.class
+        versionProvider = GitlabCloneCommand.AppVersionProvider.class,
+        sortOptions = false,
+        usageHelpAutoWidth = true
 )
 public class GitlabCloneCommand implements Runnable {
 
-    @Option(names = {"-v", "--verbose"}, description = "Print out extra information about what the tool is doing.")
+    @Option(
+            order = 0,
+            names = {"-v", "--verbose"},
+            description = "Print out extra information about what the tool is doing."
+    )
     private boolean verbose;
 
-    @Option(names = {"-x", "--very-verbose"}, description = "Print out even more information about what the tool is doing.")
+    @Option(
+            order = 1,
+            names = {"-x", "--very-verbose"},
+            description = "Print out even more information about what the tool is doing."
+    )
     private boolean veryVerbose;
 
-    @Option(names = {"--debug"}, description = "Sets all loggers to DEBUG level.")
+    @Option(
+            order = 2,
+            names = {"--debug"},
+            description = "Sets all loggers to DEBUG level."
+    )
     private boolean debug;
 
-    @Option(names = {"--trace"}, description = "Sets all loggers to TRACE level.")
+    @Option(
+            order = 3,
+            names = {"--trace"},
+            description = "Sets all loggers to TRACE level."
+    )
     private boolean trace;
 
     @CommandLine.Parameters(

--- a/src/main/java/gitlab/clone/GitlabCloneCommand.java
+++ b/src/main/java/gitlab/clone/GitlabCloneCommand.java
@@ -26,9 +26,6 @@ public class GitlabCloneCommand implements Runnable {
     @Option(names = {"-g", "--group"}, description = "The GitLab group.", required = true, paramLabel = "GROUP")
     private String gitlabGroupName;
 
-    @Option(names = {"-t", "--token"}, description = "The GitLab private token.", required = true, paramLabel = "TOKEN")
-    private String gitlabToken;
-
     @Option(names = {"-p", "--path"}, description = "The local path where to create the group clone.", paramLabel = "PATH", defaultValue = ".", showDefaultValue = CommandLine.Help.Visibility.ALWAYS)
     private String localPath;
 
@@ -39,8 +36,7 @@ public class GitlabCloneCommand implements Runnable {
     @Inject
     LoggingSystem loggingSystem;
 
-
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) {
         PicocliRunner.run(GitlabCloneCommand.class, args);
     }
 
@@ -51,8 +47,8 @@ public class GitlabCloneCommand implements Runnable {
         }
 
         log.info("Cloning group '{}'", gitlabGroupName);
-        final Flowable<Git> operations = gitlabService.searchGroups(gitlabToken, gitlabGroupName, true)
-                                                      .map(group -> gitlabService.getGitlabGroupProjects(gitlabToken, group))
+        final Flowable<Git> operations = gitlabService.searchGroups(gitlabGroupName, true)
+                                                      .map(group -> gitlabService.getGitlabGroupProjects(group))
                                                       .flatMap(projects -> cloningService.cloneProjects(projects, localPath));
 
         // have to consume all elements of iterable for the code to execute

--- a/src/main/java/gitlab/clone/GitlabCloneCommand.java
+++ b/src/main/java/gitlab/clone/GitlabCloneCommand.java
@@ -27,6 +27,15 @@ public class GitlabCloneCommand implements Runnable {
     @Option(names = {"-v", "--verbose"}, description = "Print out extra information about what the tool is doing.")
     private boolean verbose;
 
+    @Option(names = {"-x", "--very-verbose"}, description = "Print out even more information about what the tool is doing.")
+    private boolean veryVerbose;
+
+    @Option(names = {"--debug"}, description = "Sets all loggers to DEBUG level.")
+    private boolean debug;
+
+    @Option(names = {"--trace"}, description = "Sets all loggers to TRACE level.")
+    private boolean trace;
+
     @CommandLine.Parameters(
             index = "0",
             paramLabel = "GROUP",
@@ -56,8 +65,18 @@ public class GitlabCloneCommand implements Runnable {
 
     @Override
     public void run() {
-        if (verbose) {
+        if (trace) {
+            loggingSystem.setLogLevel("root", LogLevel.TRACE);
+            log.trace("All loggers set to 'TRACE'");
+        } else if (debug) {
+            loggingSystem.setLogLevel("root", LogLevel.DEBUG);
+            log.debug("All loggers set to 'DEBUG'");
+        } else if (veryVerbose) {
+            loggingSystem.setLogLevel("gitlab.clone", LogLevel.TRACE);
+            log.trace("Set 'gitlab.clone' logger to TRACE");
+        } else if (verbose) {
             loggingSystem.setLogLevel("gitlab.clone", LogLevel.DEBUG);
+            log.debug("Set 'gitlab.clone' logger to DEBUG");
         }
 
         log.info("Cloning group '{}'", gitlabGroupName);

--- a/src/main/java/gitlab/clone/GitlabCloneCommand.java
+++ b/src/main/java/gitlab/clone/GitlabCloneCommand.java
@@ -23,10 +23,20 @@ public class GitlabCloneCommand implements Runnable {
     @Option(names = {"-v", "--verbose"}, description = "Print out extra information about what the tool is doing.")
     private boolean verbose;
 
-    @Option(names = {"-g", "--group"}, description = "The GitLab group.", required = true, paramLabel = "GROUP")
+    @CommandLine.Parameters(
+            index = "0",
+            paramLabel = "GROUP",
+            description = "The GitLab group to clone."
+    )
     private String gitlabGroupName;
 
-    @Option(names = {"-p", "--path"}, description = "The local path where to create the group clone.", paramLabel = "PATH", defaultValue = ".", showDefaultValue = CommandLine.Help.Visibility.ALWAYS)
+    @CommandLine.Parameters(
+            index = "1",
+            paramLabel = "PATH",
+            description = "The local path where to create the group clone.",
+            defaultValue = ".",
+            showDefaultValue = CommandLine.Help.Visibility.ON_DEMAND
+    )
     private String localPath;
 
     @Inject

--- a/src/main/java/gitlab/clone/GitlabCloneCommand.java
+++ b/src/main/java/gitlab/clone/GitlabCloneCommand.java
@@ -11,12 +11,16 @@ import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
 import javax.inject.Inject;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 @Slf4j
 @Command(
         name = "gitlab-clone",
         description = "A tool to clone an entire GitLab group with all sub-groups and repositories.",
-        mixinStandardHelpOptions = true
+        mixinStandardHelpOptions = true,
+        versionProvider = GitlabCloneCommand.AppVersionProvider.class
 )
 public class GitlabCloneCommand implements Runnable {
 
@@ -67,4 +71,17 @@ public class GitlabCloneCommand implements Runnable {
 
         log.info("All done");
     }
+
+    static class AppVersionProvider implements CommandLine.IVersionProvider {
+
+        @Override
+        public String[] getVersion() throws Exception {
+            final URI versionFileUri = AppVersionProvider.class.getResource("/VERSION").toURI();
+            String version = new String(Files.readAllBytes(Paths.get(versionFileUri)));
+            return new String[]{
+                    "v" + version
+            };
+        }
+    }
+
 }

--- a/src/main/java/gitlab/clone/GitlabService.java
+++ b/src/main/java/gitlab/clone/GitlabService.java
@@ -16,8 +16,8 @@ public class GitlabService {
         this.client = client;
     }
 
-    public Flowable<GitlabGroup> searchGroups(String privateToken, String search, boolean onlyNameMatches) {
-        final Flowable<GitlabGroup> gitlabGroupFlowable = client.searchGroups(privateToken, search, MAX_GROUPS_PER_PAGE);
+    public Flowable<GitlabGroup> searchGroups(String search, boolean onlyNameMatches) {
+        final Flowable<GitlabGroup> gitlabGroupFlowable = client.searchGroups(search, MAX_GROUPS_PER_PAGE);
         if (onlyNameMatches) {
             log.debug("Looking for group named: {}", search);
             return gitlabGroupFlowable.filter(gitlabGroup -> gitlabGroup.getName().equalsIgnoreCase(search));
@@ -27,25 +27,25 @@ public class GitlabService {
         }
     }
 
-    public Flowable<GitlabProject> getGitlabGroupProjects(String privateToken, GitlabGroup group) {
+    public Flowable<GitlabProject> getGitlabGroupProjects(GitlabGroup group) {
         log.debug("Searching for projects in group {}", group.getFullPath());
         final String groupId = group.getId();
-        Flowable<GitlabProject> projects = getGroupProjects(privateToken, groupId);
-        Flowable<GitlabGroup> subGroups = getSubGroups(privateToken, groupId);
+        Flowable<GitlabProject> projects = getGroupProjects(groupId);
+        Flowable<GitlabGroup> subGroups = getSubGroups(groupId);
 
-        return Flowable.concat(projects, subGroups.flatMap(subGroup -> getGroupProjects(privateToken, subGroup.getId())));
+        return Flowable.concat(projects, subGroups.flatMap(subGroup -> getGroupProjects(subGroup.getId())));
     }
 
-    private Flowable<GitlabGroup> getSubGroups(String privateToken, String groupId) {
-        return getSubGroups(privateToken, groupId, 0);
+    private Flowable<GitlabGroup> getSubGroups(String groupId) {
+        return getSubGroups(groupId, 0);
     }
 
-    private Flowable<GitlabGroup> getSubGroups(String privateToken, String groupId, int page) {
+    private Flowable<GitlabGroup> getSubGroups(String groupId, int page) {
         log.trace("Looking for subgroups at page {}", page);
-        final Flowable<GitlabGroup> groups = client.groupDescendants(privateToken, groupId, true, MAX_GROUPS_PER_PAGE, page);
+        final Flowable<GitlabGroup> groups = client.groupDescendants(groupId, true, MAX_GROUPS_PER_PAGE, page);
         return Flowable.concat(groups, groups.isEmpty()
                                              .toFlowable()
-                                             .flatMap(isEmpty -> isEmpty ? Flowable.empty() : getSubGroups(privateToken, groupId, page + 1)));
+                                             .flatMap(isEmpty -> isEmpty ? Flowable.empty() : getSubGroups(groupId, page + 1)));
     }
 
     private GitlabProject logProject(GitlabProject project) {
@@ -53,7 +53,7 @@ public class GitlabService {
         return project;
     }
 
-    private Flowable<GitlabProject> getGroupProjects(String privateToken, String groupId) {
-        return client.groupProjects(privateToken, groupId).map(this::logProject);
+    private Flowable<GitlabProject> getGroupProjects(String groupId) {
+        return client.groupProjects(groupId).map(this::logProject);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,3 +5,6 @@ micronaut:
 logger:
   levels:
     gitlab.clone: INFO
+
+gitlab:
+  url: "https://gitlab.com"

--- a/src/test/java/gitlab/clone/GitlabClientTest.java
+++ b/src/test/java/gitlab/clone/GitlabClientTest.java
@@ -1,6 +1,5 @@
 package gitlab.clone;
 
-import io.micronaut.context.annotation.Value;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import io.reactivex.Flowable;
 import org.junit.jupiter.api.Test;
@@ -15,26 +14,23 @@ class GitlabClientTest {
     @Inject
     private GitlabClient client;
 
-    @Value("${gitlab.private.token}")
-    private String gitlabPrivateToken;
-
     @Test
     void searchGroups() {
-        final Flowable<GitlabGroup> groups = client.searchGroups(gitlabPrivateToken, "gitlab-clone-example", 1000);
+        final Flowable<GitlabGroup> groups = client.searchGroups("gitlab-clone-example", 1000);
 
         assertThat(groups.blockingIterable()).hasSize(4);
     }
 
     @Test
     void groupDescendants() {
-        final Flowable<GitlabGroup> groups = client.groupDescendants(gitlabPrivateToken, "11961707", true, 100, 0);
+        final Flowable<GitlabGroup> groups = client.groupDescendants("11961707", true, 100, 0);
 
         assertThat(groups.blockingIterable()).hasSize(3);
     }
 
     @Test
     void groupProjects() {
-        final Flowable<GitlabProject> groups = client.groupProjects(gitlabPrivateToken, "11961707");
+        final Flowable<GitlabProject> groups = client.groupProjects("11961707");
 
         assertThat(groups.blockingIterable()).hasSize(1);
     }

--- a/src/test/java/gitlab/clone/GitlabCloneCommandTest.java
+++ b/src/test/java/gitlab/clone/GitlabCloneCommandTest.java
@@ -26,8 +26,10 @@ public class GitlabCloneCommandTest {
             String[] args = new String[]{"-v", "-p", cloneDirectory.toPath().toString(), "-g", "gitlab-clone-example", "-t", System.getenv("GITLAB_PRIVATE_TOKEN")};
             PicocliRunner.run(GitlabCloneCommand.class, ctx, args);
 
-            // gitlab-clone
-            assertThat(baos.toString()).contains("Cloning group 'gitlab-clone-example'");
+            assertThat(baos.toString()).contains("Cloning group 'gitlab-clone-example'")
+                                       .contains("Looking for group named: gitlab-clone-example")
+                                       .contains("Searching for projects in group gitlab-clone-example")
+                                       .contains("All done");
         }
     }
 }

--- a/src/test/java/gitlab/clone/GitlabCloneCommandTest.java
+++ b/src/test/java/gitlab/clone/GitlabCloneCommandTest.java
@@ -23,7 +23,7 @@ public class GitlabCloneCommandTest {
         System.setOut(new PrintStream(baos));
 
         try (ApplicationContext ctx = ApplicationContext.run(Environment.CLI, Environment.TEST)) {
-            String[] args = new String[]{"-v", "-p", cloneDirectory.toPath().toString(), "-g", "gitlab-clone-example", "-t", System.getenv("GITLAB_PRIVATE_TOKEN")};
+            String[] args = new String[]{"-v", "gitlab-clone-example", cloneDirectory.toPath().toString()};
             PicocliRunner.run(GitlabCloneCommand.class, ctx, args);
 
             assertThat(baos.toString()).contains("Cloning group 'gitlab-clone-example'")

--- a/src/test/java/gitlab/clone/GitlabServiceTest.java
+++ b/src/test/java/gitlab/clone/GitlabServiceTest.java
@@ -1,6 +1,5 @@
 package gitlab.clone;
 
-import io.micronaut.context.annotation.Value;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import io.reactivex.Flowable;
 import org.junit.jupiter.api.Test;
@@ -18,20 +17,17 @@ class GitlabServiceTest {
     @Inject
     private GitlabService service;
 
-    @Value("${gitlab.private.token}")
-    private String gitlabPrivateToken;
-
     @Test
     void searchGroups_nameOnly() {
-        final Flowable<GitlabGroup> groups = service.searchGroups(gitlabPrivateToken, GITLAB_GROUP, true);
+        final Flowable<GitlabGroup> groups = service.searchGroups(GITLAB_GROUP, true);
 
         assertThat(groups.blockingIterable()).hasSize(1);
     }
 
     @Test
     void getGitlabGroupProjects() {
-        final GitlabGroup group = service.searchGroups(gitlabPrivateToken, GITLAB_GROUP, true).blockingFirst();
-        final Flowable<GitlabProject> projects = service.getGitlabGroupProjects(gitlabPrivateToken, group);
+        final GitlabGroup group = service.searchGroups(GITLAB_GROUP, true).blockingFirst();
+        final Flowable<GitlabProject> projects = service.getGitlabGroupProjects(group);
 
         assertThat(projects.blockingIterable()).hasSize(5);
     }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,2 +1,2 @@
 gitlab:
-  url: https://test.gitlab.com
+  url: https://gitlab.com


### PR DESCRIPTION
This PR refactors the command interface to make it easier and more intuitive. 

GitLab configurations such as url and token are now picked up from the environment.
The group and the local path are now positional parameters, instead of options.
There are 3 more options to create more verbose logs.