### PR TITLE
Replace jGit library

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -45,9 +45,12 @@ jobs:
         run: ./gradlew build nativeImage
         env:
           GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
-      - name: "[${{ runner.os }}] Run native image"
-        run: build/native-image/application
+      - name: "[${{ runner.os }}] Run and test native image"
+        run: |
+          build/native-image/application gitlab-clone-example tool-test
+          [[ -f  tool-test/gitlab-clone-example/a-project/some-project-sub-module/README.md ]]
       - name: "[${{ runner.os }}] Clean up"
+        if: ${{ always() }}
         run: sudo rm -rf ~/.ssh
       - name: '[${{ runner.os }}] Upload artifacts'
         uses: actions/upload-artifact@v2

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -46,8 +46,12 @@ jobs:
         run: ./gradlew build nativeImage
         env:
           GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
-      - name: "Run native image"
-        run: build/native-image/application
+      - name: "Run and test native image"
+        run: |
+          build/native-image/application gitlab-clone-example tool-test
+          [[ -f  tool-test/gitlab-clone-example/a-project/some-project-sub-module/README.md ]]
+        env:
+          GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
       - name: "Clean up"
         if: ${{ always() }}
         run: sudo rm -rf ~/.ssh

--- a/README.md
+++ b/README.md
@@ -42,3 +42,15 @@ Clone an entire GitLab group with all sub-groups and repositories.
       --debug          Sets all loggers to DEBUG level.
       --trace          Sets all loggers to TRACE level.
 ```
+
+## Development
+
+In order to properly build a native image some configuration needs to be generated from running the app as a jar.
+That configuration is then included as a resource for the application, and the native image builder will load that to
+properly create the single binary.
+That can be done by running the app from jar while setting a JVM agent to collect the configuration.  
+During the app run all functionality should be exercised.
+```
+./gradlew clean build
+java -agentlib:native-image-agent=config-output-dir=src/main/resources/META-INF/native-image -jar build/libs/gitlab-clone-*-all.jar ...
+```

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,8 @@ dependencies {
 
     implementation 'io.vavr:vavr:0.10.3'
 
-    implementation 'com.bacoder.jgit:org.eclipse.jgit:3.1.0-201309071158-r'
+    implementation 'org.eclipse.jgit:org.eclipse.jgit:5.11.0.202103091610-r'
+    implementation 'org.eclipse.jgit:org.eclipse.jgit.ssh.jsch:5.11.0.202103091610-r'
 
     testCompileOnly 'org.projectlombok:lombok:1.18.16'
     testAnnotationProcessor 'org.projectlombok:lombok:1.18.16'

--- a/src/main/java/gitlab/clone/CloningService.java
+++ b/src/main/java/gitlab/clone/CloningService.java
@@ -23,12 +23,14 @@ import java.nio.file.FileSystems;
 @Singleton
 public class CloningService {
 
-    private final SshSessionFactory sshSessionFactory = new JschConfigSessionFactory() {
+    public static final SshSessionFactory SSH_SESSION_FACTORY = new JschConfigSessionFactory() {
         @Override
         protected void configure(OpenSshConfig.Host host, Session session) {
-            java.util.Properties config = new java.util.Properties();
-            config.put("StrictHostKeyChecking", "no");
-            session.setConfig(config);
+            log.trace("ssh :: host = {}", host.getHostName());
+            log.trace("ssh :: port = {}", host.getPort());
+            log.trace("ssh :: preferred auth = {}", host.getPreferredAuthentications());
+            log.trace("ssh :: strict host key checking = {}", host.getStrictHostKeyChecking());
+            log.trace("ssh :: username = {}", session.getUserName());
         }
     };
 
@@ -74,8 +76,9 @@ public class CloningService {
         cloneCommand.setCloneSubmodules(true);
         cloneCommand.setTransportConfigCallback(transport -> {
             SshTransport sshTransport = (SshTransport) transport;
-            sshTransport.setSshSessionFactory(sshSessionFactory);
+            sshTransport.setSshSessionFactory(SSH_SESSION_FACTORY);
         });
+
         return cloneCommand.call();
     }
 

--- a/src/main/java/gitlab/clone/GitlabCloneCommand.java
+++ b/src/main/java/gitlab/clone/GitlabCloneCommand.java
@@ -101,17 +101,23 @@ public class GitlabCloneCommand implements Runnable {
     @Override
     public void run() {
         if (trace) {
+            LoggerUtils.disableDefaultAppender();
             loggingSystem.setLogLevel("root", LogLevel.TRACE);
             log.trace("All loggers set to 'TRACE'");
         } else if (debug) {
+            LoggerUtils.disableDefaultAppender();
             loggingSystem.setLogLevel("root", LogLevel.DEBUG);
             log.debug("All loggers set to 'DEBUG'");
         } else if (veryVerbose) {
+            LoggerUtils.disableFullAppender();
             loggingSystem.setLogLevel("gitlab.clone", LogLevel.TRACE);
             log.trace("Set 'gitlab.clone' logger to TRACE");
         } else if (verbose) {
+            LoggerUtils.disableFullAppender();
             loggingSystem.setLogLevel("gitlab.clone", LogLevel.DEBUG);
             log.debug("Set 'gitlab.clone' logger to DEBUG");
+        } else {
+            LoggerUtils.disableFullAppender();
         }
 
         log.info("Cloning group '{}'", gitlabGroupName);

--- a/src/main/java/gitlab/clone/LoggerUtils.java
+++ b/src/main/java/gitlab/clone/LoggerUtils.java
@@ -1,0 +1,27 @@
+package gitlab.clone;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.ConsoleAppender;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LoggerUtils {
+
+    public static final String FULL = "FULL";
+    public static final String DEFAULT = "DEFAULT";
+
+    public static void disableFullAppender() {
+        LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
+        ConsoleAppender<ILoggingEvent> appender =
+                (ConsoleAppender) lc.getLogger(Logger.ROOT_LOGGER_NAME).getAppender(FULL);
+        appender.stop();
+    }
+
+    public static void disableDefaultAppender() {
+        LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
+        ConsoleAppender<ILoggingEvent> appender =
+                (ConsoleAppender) lc.getLogger(Logger.ROOT_LOGGER_NAME).getAppender(DEFAULT);
+        appender.stop();
+    }
+}

--- a/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/reflect-config.json
@@ -9,6 +9,10 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
+  "name":"ch.qos.logback.classic.pattern.DateConverter",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
   "name":"ch.qos.logback.classic.pattern.LevelConverter",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
@@ -17,7 +21,15 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
+  "name":"ch.qos.logback.classic.pattern.LoggerConverter",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
   "name":"ch.qos.logback.classic.pattern.MessageConverter",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"ch.qos.logback.classic.pattern.ThreadConverter",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
@@ -68,6 +80,18 @@
   "name":"com.fasterxml.jackson.databind.ser.Serializers[]"
 },
 {
+  "name":"com.jcraft.jsch.DHEC256",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"com.jcraft.jsch.DHEC384",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"com.jcraft.jsch.DHEC521",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
   "name":"com.jcraft.jsch.DHG14",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
@@ -104,19 +128,15 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "name":"com.jcraft.jsch.jce.ARCFOUR",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
-  "name":"com.jcraft.jsch.jce.ARCFOUR128",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
-  "name":"com.jcraft.jsch.jce.ARCFOUR256",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
   "name":"com.jcraft.jsch.jce.DH",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"com.jcraft.jsch.jce.ECDHN",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"com.jcraft.jsch.jce.HMACSHA1",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
@@ -132,11 +152,31 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "name":"com.jcraft.jsch.jce.SignatureRSA",
+  "name":"com.jcraft.jsch.jce.SHA256",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "name":"com.jcraft.jsch.jce.TripleDESCBC",
+  "name":"com.jcraft.jsch.jce.SHA384",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"com.jcraft.jsch.jce.SHA512",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"com.jcraft.jsch.jce.SignatureECDSA256",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"com.jcraft.jsch.jce.SignatureECDSA384",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"com.jcraft.jsch.jce.SignatureECDSA521",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"com.jcraft.jsch.jce.SignatureRSA",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
@@ -144,15 +184,7 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "name":"com.jcraft.jsch.jcraft.HMACSHA1",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
   "name":"com.sun.crypto.provider.AESCipher$General",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
-  "name":"com.sun.crypto.provider.ARCFOURCipher",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
@@ -168,10 +200,6 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "name":"com.sun.crypto.provider.DHKeyFactory",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
   "name":"com.sun.crypto.provider.DHKeyPairGenerator",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
@@ -181,6 +209,10 @@
 },
 {
   "name":"com.sun.crypto.provider.HmacCore$HmacSHA256",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"com.sun.crypto.provider.HmacSHA1",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
@@ -211,6 +243,12 @@
   "name":"gitlab.clone.GitlabCloneCommand",
   "allDeclaredFields":true,
   "allDeclaredMethods":true
+},
+{
+  "name":"gitlab.clone.GitlabCloneCommand$AppVersionProvider",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
   "name":"gitlab.clone.GitlabGroup",
@@ -1123,13 +1161,6 @@
   "name":"io.reactivex.Single"
 },
 {
-  "name":"java.io.File",
-  "methods":[
-    {"name":"canExecute","parameterTypes":[] }, 
-    {"name":"setExecutable","parameterTypes":["boolean"] }
-  ]
-},
-{
   "name":"java.io.FilePermission"
 },
 {
@@ -1197,6 +1228,12 @@
 },
 {
   "name":"java.security.SecurityPermission"
+},
+{
+  "name":"java.security.interfaces.ECPrivateKey"
+},
+{
+  "name":"java.security.interfaces.ECPublicKey"
 },
 {
   "name":"java.security.interfaces.RSAPrivateKey"
@@ -1316,6 +1353,22 @@
 },
 {
   "name":"org.eclipse.jgit.lib.CoreConfig$CheckStat",
+  "methods":[{"name":"values","parameterTypes":[] }]
+},
+{
+  "name":"org.eclipse.jgit.lib.CoreConfig$EOL",
+  "methods":[{"name":"values","parameterTypes":[] }]
+},
+{
+  "name":"org.eclipse.jgit.lib.CoreConfig$HideDotFiles",
+  "methods":[{"name":"values","parameterTypes":[] }]
+},
+{
+  "name":"org.eclipse.jgit.lib.CoreConfig$LogRefUpdates",
+  "methods":[{"name":"values","parameterTypes":[] }]
+},
+{
+  "name":"org.eclipse.jgit.lib.CoreConfig$SymLinks",
   "methods":[{"name":"values","parameterTypes":[] }]
 },
 {

--- a/src/main/resources/META-INF/native-image/resource-config.json
+++ b/src/main/resources/META-INF/native-image/resource-config.json
@@ -9,6 +9,7 @@
     {"pattern":"\\QMETA-INF/services/io.micronaut.inject.BeanConfiguration\\E"}, 
     {"pattern":"\\QMETA-INF/services/io.micronaut.inject.BeanDefinitionReference\\E"}, 
     {"pattern":"\\QMETA-INF/services/java.nio.file.spi.FileSystemProvider\\E"}, 
+    {"pattern":"\\QMETA-INF/services/org.eclipse.jgit.transport.SshSessionFactory\\E"}, 
     {"pattern":"\\Qapplication.yml\\E"}, 
     {"pattern":"\\Qlogback.xml\\E"}, 
     {"pattern":"\\Qorg/slf4j/impl/StaticLoggerBinder.class\\E"}

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,17 +1,22 @@
 <configuration>
 
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <appender name="DEFAULT" class="ch.qos.logback.core.ConsoleAppender">
         <withJansi>true</withJansi>
-        <!-- encoders are assigned the type
-             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
         <encoder>
-            <pattern>%highlight(%-5level) - %msg%n
-            </pattern>
+            <pattern>%highlight(%-5level) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="FULL" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>true</withJansi>
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 
     <root level="warn">
-        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="DEFAULT"/>
+        <appender-ref ref="FULL"/>
     </root>
 
 </configuration>


### PR DESCRIPTION
This PR replaces the jGit library to try and mitigate some cloning via ssh errors, or at least get better logging when errors do happen. This PR also adds a new logger layout that prints threads and classes together with log events. The new layout is activated when `--debug` and `--trace` options are selected.