### PR TITLE
Fix bug in loading user SSH config and keys in OpenSSH format

### DIFF
--- a/.github/scripts/merge-native-image-build-config.sh
+++ b/.github/scripts/merge-native-image-build-config.sh
@@ -20,7 +20,7 @@ mkdir -p "${output_dir}"
 
 say "Merging native-image build config"
 input_dirs=""
-for config_dir in ${native_image_config_dir}/*/*; do
+for config_dir in "${native_image_config_dir}"/*/*; do
   input_dirs+="--input-dir=${config_dir} "
 done
 

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: DeLaGuardo/setup-graalvm@4.0
         with:
           graalvm: '21.1.0'
-          java: 'java11'
+          java: 'java16'
           arch: 'amd64'
       - name: "[${{ runner.os }}] Install native-image"
         run: gu install native-image

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -21,12 +21,12 @@ jobs:
           path: |
             ~/.gradle
             ${GITHUB_WORKSPACE}/.gradle
-          key: ${{ matrix.os }}-gitlab-clone-release-java16
+          key: ${{ matrix.os }}-gitlab-clone-release-java11
       - name: "[${{ runner.os }}] Install GraalVM"
         uses: DeLaGuardo/setup-graalvm@4.0
         with:
           graalvm: '21.1.0'
-          java: 'java16'
+          java: 'java11'
           arch: 'amd64'
       - name: "[${{ runner.os }}] Install native-image"
         run: gu install native-image

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -21,7 +21,7 @@ jobs:
           path: |
             ~/.gradle
             ${GITHUB_WORKSPACE}/.gradle
-          key: ${{ matrix.os }}-gitlab-clone-release
+          key: ${{ matrix.os }}-gitlab-clone-release-java16
       - name: "[${{ runner.os }}] Install GraalVM"
         uses: DeLaGuardo/setup-graalvm@4.0
         with:

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -22,12 +22,12 @@ jobs:
             ~/.gradle
             ${GITHUB_WORKSPACE}/.gradle
             ~/.cache/pip/
-          key: ${{ runner.os }}-gitlab-clone-development-java16
+          key: ${{ runner.os }}-gitlab-clone-development-java11
       - name: "Install GraalVM"
         uses: DeLaGuardo/setup-graalvm@4.0
         with:
           graalvm: '21.1.0'
-          java: 'java16'
+          java: 'java11'
           arch: 'amd64'
       - name: "Install native-image"
         run: |

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -26,7 +26,7 @@ jobs:
         uses: DeLaGuardo/setup-graalvm@4.0
         with:
           graalvm: '21.1.0'
-          java: 'java11'
+          java: 'java16'
           arch: 'amd64'
       - name: "Install native-image"
         run: |

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -21,6 +21,7 @@ jobs:
           path: |
             ~/.gradle
             ${GITHUB_WORKSPACE}/.gradle
+            ~/.cache/pip/
           key: ${{ runner.os }}-gitlab-clone-development
       - name: "Install GraalVM"
         uses: DeLaGuardo/setup-graalvm@4.0

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -22,7 +22,7 @@ jobs:
             ~/.gradle
             ${GITHUB_WORKSPACE}/.gradle
             ~/.cache/pip/
-          key: ${{ runner.os }}-gitlab-clone-development
+          key: ${{ runner.os }}-gitlab-clone-development-java16
       - name: "Install GraalVM"
         uses: DeLaGuardo/setup-graalvm@4.0
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -62,12 +62,6 @@ java {
     targetCompatibility = JavaVersion.toVersion("11")
 }
 
-run {
-    moduleOptions {
-        addOpens = ['jdk.compiler/com.sun.tools.javac.processing': 'ALL-UNNAMED']
-    }
-}
-
 test {
     environment "GITLAB_TOKEN", System.getenv('GITLAB_TOKEN')
     moduleOptions {

--- a/build.gradle
+++ b/build.gradle
@@ -58,8 +58,8 @@ application {
 
 java {
     modularity.inferModulePath.set(true)
-    sourceCompatibility = JavaVersion.toVersion("15")
-    targetCompatibility = JavaVersion.toVersion("15")
+    sourceCompatibility = JavaVersion.toVersion("11")
+    targetCompatibility = JavaVersion.toVersion("11")
 }
 
 run {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
-    id("com.github.johnrengelman.shadow") version "6.1.0"
+    id("com.github.johnrengelman.shadow") version "7.0.0"
     id("io.micronaut.application") version "1.4.2"
+    id 'org.javamodularity.moduleplugin' version '1.8.3'
 }
 
 version = rootProject.file('VERSION').text.trim()
@@ -19,9 +20,8 @@ micronaut {
 }
 
 dependencies {
-
-    compileOnly 'org.projectlombok:lombok:1.18.16'
-    annotationProcessor 'org.projectlombok:lombok:1.18.16'
+    compileOnly 'org.projectlombok:lombok:1.18.20'
+    annotationProcessor 'org.projectlombok:lombok:1.18.20'
 
     annotationProcessor("info.picocli:picocli-codegen")
     implementation("info.picocli:picocli")
@@ -38,12 +38,18 @@ dependencies {
     implementation 'io.vavr:vavr:0.10.3'
 
     implementation 'org.eclipse.jgit:org.eclipse.jgit:5.11.0.202103091610-r'
-    implementation 'org.eclipse.jgit:org.eclipse.jgit.ssh.jsch:5.11.0.202103091610-r'
+    implementation('org.eclipse.jgit:org.eclipse.jgit.ssh.jsch:5.11.0.202103091610-r') {
+        exclude module: 'jsch'
+    }
 
-    testCompileOnly 'org.projectlombok:lombok:1.18.16'
-    testAnnotationProcessor 'org.projectlombok:lombok:1.18.16'
+    implementation 'com.github.mwiede:jsch:0.1.62'
+
+    testCompileOnly 'org.projectlombok:lombok:1.18.20'
+    testAnnotationProcessor 'org.projectlombok:lombok:1.18.20'
     testImplementation 'org.assertj:assertj-core:3.11.1'
     testImplementation 'org.assertj:assertj-vavr:0.4.1'
+
+    testImplementation("org.junit.jupiter:junit-jupiter-engine") // make gradle compileTestJava work
 }
 
 application {
@@ -51,16 +57,30 @@ application {
 }
 
 java {
-    sourceCompatibility = JavaVersion.toVersion("11")
-    targetCompatibility = JavaVersion.toVersion("11")
+    modularity.inferModulePath.set(true)
+    sourceCompatibility = JavaVersion.toVersion("15")
+    targetCompatibility = JavaVersion.toVersion("15")
+}
+
+run {
+    moduleOptions {
+        addOpens = ['jdk.compiler/com.sun.tools.javac.processing': 'ALL-UNNAMED']
+    }
 }
 
 test {
     environment "GITLAB_TOKEN", System.getenv('GITLAB_TOKEN')
-//    maxHeapSize = "1G"
-//    forkEvery = 1
+    moduleOptions {
+        runOnClasspath = true
+    }
 }
 
 processResources {
     from("VERSION")
 }
+
+modularity.patchModule('java.annotation', 'jsr305-3.0.2.jar')
+modularity.patchModule('org.eclipse.jgit', 'org.eclipse.jgit.ssh.jsch-5.11.0.202103091610-r.jar')
+modularity.patchModule('io.micronaut.runtime', 'micronaut-context-2.5.0.jar')
+
+mainClassName = "$moduleName/gitlab.clone.GitlabCloneCommand"

--- a/src/main/java/gitlab/clone/GitService.java
+++ b/src/main/java/gitlab/clone/GitService.java
@@ -83,14 +83,14 @@ public class GitService {
 
         final CloneCommand cloneCommand = Git.cloneRepository();
         switch (cloneProtocol) {
-            case SSH -> {
+            case SSH:
                 cloneCommand.setURI(project.getSshUrlToRepo());
                 cloneCommand.setTransportConfigCallback(transport -> {
                     SshTransport sshTransport = (SshTransport) transport;
                     sshTransport.setSshSessionFactory(sshSessionFactory);
                 });
-            }
-            case HTTPS -> {
+                break;
+            case HTTPS:
                 cloneCommand.setURI(project.getHttpUrlToRepo());
                 final String username = Objects.requireNonNullElse(httpsUsername, "");
                 final String password = Objects.requireNonNullElse(httpsPassword, "");
@@ -99,7 +99,7 @@ public class GitService {
                 } else {
                     log.debug("Credentials for HTTPS remote not set, group to clone must be public.");
                 }
-            }
+                break;
         }
         cloneCommand.setDirectory(new File(pathToClone));
         cloneCommand.setCloneSubmodules(cloneSubmodules);

--- a/src/main/java/gitlab/clone/GitlabClient.java
+++ b/src/main/java/gitlab/clone/GitlabClient.java
@@ -1,9 +1,5 @@
 package gitlab.clone;
 
-import static gitlab.clone.GitlabClient.H_PRIVATE_TOKEN;
-
-import java.util.List;
-
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.annotation.Get;
 import io.micronaut.http.annotation.Header;
@@ -12,6 +8,10 @@ import io.micronaut.http.annotation.QueryValue;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.retry.annotation.Retryable;
 import io.reactivex.Flowable;
+
+import java.util.List;
+
+import static gitlab.clone.GitlabClient.H_PRIVATE_TOKEN;
 
 @Retryable
 @Client("${gitlab.url}/api/v4")
@@ -42,4 +42,7 @@ public interface GitlabClient {
             @QueryValue(value = "per_page") int perPage,
             @QueryValue int page
     );
+
+    @Get("/version")
+    GitlabVersion version();
 }

--- a/src/main/java/gitlab/clone/GitlabVersion.java
+++ b/src/main/java/gitlab/clone/GitlabVersion.java
@@ -1,0 +1,18 @@
+package gitlab.clone;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.micronaut.core.annotation.Introspected;
+import lombok.AllArgsConstructor;
+import lombok.ToString;
+
+@Introspected
+@AllArgsConstructor
+@ToString
+public class GitlabVersion {
+    String version;
+    String revision;
+
+    @JsonCreator
+    public GitlabVersion() {
+    }
+}

--- a/src/main/java/gitlab/clone/OverrideJschConfigSessionFactory.java
+++ b/src/main/java/gitlab/clone/OverrideJschConfigSessionFactory.java
@@ -1,0 +1,42 @@
+package gitlab.clone;
+
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.OpenSSHConfig;
+import com.jcraft.jsch.Session;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.jgit.transport.JschConfigSessionFactory;
+import org.eclipse.jgit.transport.OpenSshConfig;
+import org.eclipse.jgit.util.FS;
+
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.util.Objects;
+
+@Slf4j
+public class OverrideJschConfigSessionFactory extends JschConfigSessionFactory {
+    static {
+        JSch.setConfig("signature.rsa", JSch.getConfig("ssh-rsa"));
+    }
+
+    @Override
+    protected JSch getJSch(OpenSshConfig.Host hc, FS fs) throws JSchException {
+        final JSch jSch = super.getJSch(hc, fs);
+        final String separator = FileSystems.getDefault().getSeparator();
+        String configFilePath = Objects.requireNonNullElse(System.getProperty("user.home"), ".") + separator + ".ssh" + separator + "config";
+        try {
+            // jGit uses a patched config repository (in super.getJSch(hc, fs)) that prevents proper loading of the ssh config,
+            // so, we re-set it to an implementation that works
+            // patched repository: org.eclipse.jgit.transport.JschBugFixingConfigRepository
+            jSch.setConfigRepository(OpenSSHConfig.parseFile(configFilePath));
+        } catch (IOException e) {
+            log.warn("Could not load SSH config file at " + configFilePath, e);
+        }
+        return jSch;
+    }
+
+    @Override
+    protected void configure(OpenSshConfig.Host hc, Session session) {
+        session.setConfig("PreferredAuthentications", "publickey");
+    }
+}

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,22 @@
+module gitlab.clone {
+    requires static lombok;
+    requires logback.classic;
+    requires org.slf4j;
+    requires com.fasterxml.jackson.databind;
+    requires io.vavr;
+    requires io.micronaut.http_client;
+    requires io.micronaut.runtime;
+    requires io.micronaut.inject;
+    requires io.micronaut.http;
+    requires io.micronaut.http_client_core;
+    requires io.reactivex.rxjava2;
+    requires javax.inject;
+    requires info.picocli;
+    requires org.eclipse.jgit;
+    // merged with org.eclipse.jgit to prevent split package
+    // requires org.eclipse.jgit.ssh.jsch;
+    requires jsch;
+    requires io.micronaut.core;
+
+    exports gitlab.clone;
+}

--- a/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/reflect-config.json
@@ -1,5 +1,9 @@
 [
 {
+  "name":"apple.security.AppleProvider",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
   "name":"byte[]"
 },
 {
@@ -83,6 +87,14 @@
   "name":"com.fasterxml.jackson.databind.ser.Serializers[]"
 },
 {
+  "name":"com.jcraft.jsch.DH25519",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"com.jcraft.jsch.DH448",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
   "name":"com.jcraft.jsch.DHEC256",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
@@ -99,6 +111,26 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
+  "name":"com.jcraft.jsch.DHG14256",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"com.jcraft.jsch.DHG15",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"com.jcraft.jsch.DHG16",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"com.jcraft.jsch.DHG17",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"com.jcraft.jsch.DHG18",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
   "name":"com.jcraft.jsch.UserAuthNone",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
@@ -107,15 +139,11 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "name":"com.jcraft.jsch.jce.AES128CBC",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
   "name":"com.jcraft.jsch.jce.AES128CTR",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "name":"com.jcraft.jsch.jce.AES192CBC",
+  "name":"com.jcraft.jsch.jce.AES128GCM",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
@@ -123,11 +151,11 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "name":"com.jcraft.jsch.jce.AES256CBC",
+  "name":"com.jcraft.jsch.jce.AES256CTR",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "name":"com.jcraft.jsch.jce.AES256CTR",
+  "name":"com.jcraft.jsch.jce.AES256GCM",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
@@ -143,7 +171,19 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "name":"com.jcraft.jsch.jce.MD5",
+  "name":"com.jcraft.jsch.jce.HMACSHA256",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"com.jcraft.jsch.jce.HMACSHA256ETM",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"com.jcraft.jsch.jce.HMACSHA512",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"com.jcraft.jsch.jce.HMACSHA512ETM",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
@@ -179,23 +219,15 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "name":"com.jcraft.jsch.jce.SignatureRSA",
+  "name":"com.jcraft.jsch.jce.SignatureRSASHA256",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "name":"com.jcraft.jsch.jce.TripleDESCTR",
+  "name":"com.jcraft.jsch.jce.SignatureRSASHA512",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
   "name":"com.sun.crypto.provider.AESCipher$General",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
-  "name":"com.sun.crypto.provider.DESedeCipher",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
-  "name":"com.sun.crypto.provider.DESedeKeyFactory",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
@@ -215,7 +247,7 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "name":"com.sun.crypto.provider.HmacSHA1",
+  "name":"com.sun.crypto.provider.HmacCore$HmacSHA512",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
@@ -248,6 +280,10 @@
 },
 {
   "name":"gitlab.clone.$GitlabServiceDefinitionClass",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"gitlab.clone.$GitlabVersion$IntrospectionRef",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
@@ -1158,6 +1194,14 @@
   "allDeclaredMethods":true
 },
 {
+  "name":"java.lang.ProcessBuilder",
+  "methods":[{"name":"redirectError","parameterTypes":["java.lang.ProcessBuilder$Redirect"] }]
+},
+{
+  "name":"java.lang.ProcessBuilder$Redirect",
+  "fields":[{"name":"INHERIT"}]
+},
+{
   "name":"java.lang.RuntimePermission"
 },
 {
@@ -1432,15 +1476,7 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "name":"sun.security.provider.JavaKeyStore$DualFormatJKS",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
   "name":"sun.security.provider.JavaKeyStore$JKS",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
-  "name":"sun.security.provider.MD5",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
@@ -1472,10 +1508,6 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "name":"sun.security.provider.certpath.PKIXCertPathValidator",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
   "name":"sun.security.rsa.RSAKeyFactory$Legacy",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
@@ -1484,19 +1516,11 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "name":"sun.security.rsa.RSASignature$SHA1withRSA",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
   "name":"sun.security.rsa.RSASignature$SHA224withRSA",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "name":"sun.security.rsa.RSASignature$SHA256withRSA",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
-  "name":"sun.security.rsa.RSASignature$SHA384withRSA",
+  "name":"sun.security.rsa.RSASignature$SHA512withRSA",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {

--- a/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/reflect-config.json
@@ -1,9 +1,5 @@
 [
 {
-  "name":"apple.security.AppleProvider",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
   "name":"byte[]"
 },
 {
@@ -1194,14 +1190,6 @@
   "allDeclaredMethods":true
 },
 {
-  "name":"java.lang.ProcessBuilder",
-  "methods":[{"name":"redirectError","parameterTypes":["java.lang.ProcessBuilder$Redirect"] }]
-},
-{
-  "name":"java.lang.ProcessBuilder$Redirect",
-  "fields":[{"name":"INHERIT"}]
-},
-{
   "name":"java.lang.RuntimePermission"
 },
 {
@@ -1476,6 +1464,10 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
+  "name":"sun.security.provider.JavaKeyStore$DualFormatJKS",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
   "name":"sun.security.provider.JavaKeyStore$JKS",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
@@ -1508,6 +1500,10 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
+  "name":"sun.security.provider.certpath.PKIXCertPathValidator",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
   "name":"sun.security.rsa.RSAKeyFactory$Legacy",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
@@ -1517,6 +1513,14 @@
 },
 {
   "name":"sun.security.rsa.RSASignature$SHA224withRSA",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.rsa.RSASignature$SHA256withRSA",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.rsa.RSASignature$SHA384withRSA",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {

--- a/src/main/resources/META-INF/services/org.eclipse.jgit.transport.SshSessionFactory
+++ b/src/main/resources/META-INF/services/org.eclipse.jgit.transport.SshSessionFactory
@@ -1,0 +1,1 @@
+gitlab.clone.OverrideJschConfigSessionFactory


### PR DESCRIPTION
To do that the jCraft jSch library was replaced by a fork that supports the new key format.
But since that implementation requires Java 15, the version of Java was upgraded and that implied modularizing the project.