### PR TITLE
Fix fetching groups for gitlab pre 13.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Continuous Integration](https://github.com/miguelaferreira/gitlab-clone/actions/workflows/development.yml/badge.svg)](https://github.com/miguelaferreira/gitlab-clone/actions/workflows/development.yml)
 [![Continuous Delivery](https://github.com/miguelaferreira/gitlab-clone/actions/workflows/create-release.yaml/badge.svg)](https://github.com/miguelaferreira/gitlab-clone/actions/workflows/create-release.yaml)
+[![Known Vulnerabilities](https://snyk.io/test/github/miguelaferreira/gitlab-clone/badge.svg)](https://snyk.io/test/github/miguelaferreira/gitlab-clone)
 
 ## GitLab Clone
 

--- a/README.md
+++ b/README.md
@@ -4,30 +4,30 @@
 
 ## GitLab Clone
 
-GitLab offers the ability to create groups of repositories and then leverage those groups to manage multiple repositories at one.
-Things like CI/CD, user membership can be defined at the group level and then inherited by all the underlying repositories.
-Furthermore, it's also possible to create relationships between repositories simply by leveraging the group structure.
-For example, one can include git sub-modules and reference them by their relative path.
+GitLab offers the ability to create groups of repositories and then leverage those groups to manage multiple
+repositories at one. Things like CI/CD, user membership can be defined at the group level and then inherited by all the
+underlying repositories. Furthermore, it's also possible to create relationships between repositories simply by
+leveraging the group structure. For example, one can include git sub-modules and reference them by their relative path.
 
-It's handy, and sometimes needed, to clone the groups of repositories preserving the group structure.
-That is what this tool does.
+It's handy, and sometimes needed, to clone the groups of repositories preserving the group structure. That is what this
+tool does.
 
 ## Installing
 
-The `gitlab-clone` tool is built for two operating systems Linux and macOS.
-Each release on this repository provides binaries for these two operating systems.
-To install the tool, either download the binary from the latest release, make it executable and place it on a reachable path;
-or use `brew`.
+The `gitlab-clone` tool is built for two operating systems Linux and macOS. Each release on this repository provides
+binaries for these two operating systems. To install the tool, either download the binary from the latest release, make
+it executable and place it on a reachable path; or use `brew`.
+
 ```bash
 brew install miguelaferreira/tools/gitlab-clone
 ```
 
 ## Usage
 
-Both the gitlab url (`GITLAB_URL`) and the private token (`GITLAB_TOKEN`) for accessing GitLab API are read from the environment.
-The GitLab url defaults to [https://gitlab.com](https://gitlab.com) when not defined in the environment.
-For cloning public groups no token is needed, for private groups a token with scope `read_api` is required.
-See GitLab's [Limiting scopes of a personal access token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#limiting-scopes-of-a-personal-access-token)
+Both the gitlab url (`GITLAB_URL`) and the private token (`GITLAB_TOKEN`) for accessing GitLab API are read from the
+environment. The GitLab url defaults to [https://gitlab.com](https://gitlab.com) when not defined in the environment.
+For cloning public groups no token is needed, for private groups a token with scope `read_api` is required. See
+GitLab's [Limiting scopes of a personal access token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#limiting-scopes-of-a-personal-access-token)
 for more details on token scopes.
 
 ```
@@ -71,35 +71,46 @@ Copyright(c) 2021 - Miguel Ferreira - GitHub/GitLab: @miguelaferreira
 
 The tool supports both SSH and HTTPS protocols for cloning projects, SSH being the default protocol.
 
-There are two requirements for cloning via SSH that apply to both public and private groups:
-1. A known hosts file containing and entry for the GitLab server must exist in the default location (`${HOME}/.ssh/known_hosts`).
-   This entry looks something like this: `gitlab.com,172.65.251.78 ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFSMqzJeV9rUzU4kWitGjeR4PWSa29SPqJ1fVkhtj3Hw9xjLVXVYrU9QlYWrOLXBpQ6KWjbjTDTdDkoohFzgbEY=`
-2. A valid private key must exist in the default location (`${HOME}/.ssh/id_rsa`) or in a different location as long there is an entry for the GitLab server in the ssh client configuration that points to the correct key.
-   See [GitLab documentation on configuring SSH access](https://docs.gitlab.com/ee/ssh/) for more information on how to set this up.
+#### SSH
 
-Cloning via HTTPS (cli option `--clone-protocol=HTTPS`) does not require any setup for public groups.
-For private groups, the username needs to be provided (cli option `--https-username=<USERNAME>`).
-The GitLab token specified on the environment will be used as the password for the HTTPS authentication.
+There are two requirements for cloning via SSH that apply to both public and private groups:
+
+1. A known hosts file containing and entry for the GitLab server must exist in the default
+   location (`${HOME}/.ssh/known_hosts`). This entry looks something like
+   this: `gitlab.com,172.65.251.78 ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFSMqzJeV9rUzU4kWitGjeR4PWSa29SPqJ1fVkhtj3Hw9xjLVXVYrU9QlYWrOLXBpQ6KWjbjTDTdDkoohFzgbEY=`
+2. A private key must exist in the default location (`${HOME}/.ssh/id_rsa`) or in a different location as long there is
+   an entry for the GitLab server in the ssh client configuration that points to the correct key.
+   See [GitLab documentation on configuring SSH access](https://docs.gitlab.com/ee/ssh/) for more information on how to
+   set this up
+
+Cloning via HTTPS (cli option `--clone-protocol=HTTPS`) does not require any setup for public groups. For private
+groups, the username needs to be provided (cli option `--https-username=<USERNAME>`). The GitLab token specified on the
+environment will be used as the password for the HTTPS authentication.
 
 ## Development
 
 ### Setup
 
-SDKMAN automates the process of installing and upgrading sdks, namely Java sdks.
-Install is via.
+SDKMAN automates the process of installing and upgrading sdks, namely Java sdks. Install is via.
+
 ```bash
 curl -s "https://get.sdkman.io" | bash
 ```
+
 Then install GraalVM.
+
 ```bash
 sdk install java 21.1.0.r11-grl
 ```
+
 Load the installed GraalVM on the current terminal.
+
 ```bash
 sdk use java 21.1.0.r11-grl
 ```
 
 To build native images using GraalVM it is necessary to install the `native-image` tool.
+
 ```
 ~/.sdkman/candidates/java/21.1.0.r11-grl/bin/gu install native-image
 ```
@@ -108,47 +119,58 @@ You should be ready to build the tool.
 
 ### Build with Gradle
 
-Gradle is configured to build both executable jars and GraalVM native images.
-Gradle will also want to run tests, and the tests require a GitLab token with `read_api` scope.
-The token is picked up from the environment variable `GITLAB_TOKEN`.
-The tests can be skipped with the gradle flag `-x test`, in which case the GitLab token isn't needed anymore.
+Gradle is configured to build both executable jars and GraalVM native images. Gradle will also want to run tests, and
+the tests require a GitLab token with `read_api` scope. The token is picked up from the environment
+variable `GITLAB_TOKEN`. The tests can be skipped with the gradle flag `-x test`, in which case the GitLab token isn't
+needed anymore.
 
 To build an executable jar run gradle task `build`.
+
 ```bash
 GITLAB_TOKEN="..." ./gradlew clean build
 ```
+
 The executable jar is created under `build/libs/`, and it will be called something like `gitlab-clone-VERSION-all.jar`.
 To execute that jar run `java`.
+
 ```bash
 java -jar build/libs/gitlab-clone-*-all.jar -h
 ```
 
 To build a GraalVM native binary run the `nativeImage` gradle task.
+
 ```bash
 GITLAB_TOKEN="..." ./gradlew clean nativeImage
 ```
-The binary will be created under `build/native-image/application`.
-To execute the native binary run it.
+
+The binary will be created under `build/native-image/application`. To execute the native binary run it.
+
 ```bash
 build/native-image/application -h
 ```
 
 ### GraalVM Config
-In order to properly build a native binary some configuration needs to be generated from running the app as a jar.
-That configuration is then included as a resource for the application, and the native image builder will load that to
-properly create the native binary.
-That can be done by running the app from jar while setting a JVM agent to collect the configuration.
-During the app run all functionality should be exercised.
+
+In order to properly build a native binary some configuration needs to be generated from running the app as a jar. That
+configuration is then included as a resource for the application, and the native image builder will load that to
+properly create the native binary. That can be done by running the app from jar while setting a JVM agent to collect the
+configuration. During the app run all functionality should be exercised.
+
 ```
 ./gradlew clean build
 java -agentlib:native-image-agent=config-output-dir=src/main/resources/META-INF/native-image -jar build/libs/gitlab-clone-*-all.jar ...
 ```
-However, not all functionality of the app can be exercised in a single run (eg. cloning via SSH vs HTTPS).
-Therefore, different executions need to be made (as many as different and independent features of the app), each generating a set of config, which at the end needs to be merged.
-See the [native-image manual](https://www.graalvm.org/reference-manual/native-image/BuildConfiguration/#the-native-image-configure-tool) for more information on how this works.
-Since the tool that merges the configuration (`native-image-configure-launcher`) is not shipped with graalvm releases, it has to be built.
-This project includes two binaries of the tool, one for macOS and the other for Linux, under [graalvm/bin](./graalvm/bin).
-During CI workflows that run on PR to `main` branch, the app is executed with the `native-image-agent` producing different sets of configurations for different combinations of input options and parameters.
-This is done in script [.github/scripts/create-native-image-build-config.sh](.github/scripts/create-native-image-build-config.sh).
-Then the generated configurations are merged into the project's sources by another script, [.github/scripts/merge-native-image-build-config.sh](.github/scripts/merge-native-image-build-config.sh).
+
+However, not all functionality of the app can be exercised in a single run (eg. cloning via SSH vs HTTPS). Therefore,
+different executions need to be made (as many as different and independent features of the app), each generating a set
+of config, which at the end needs to be merged. See
+the [native-image manual](https://www.graalvm.org/reference-manual/native-image/BuildConfiguration/#the-native-image-configure-tool)
+for more information on how this works. Since the tool that merges the configuration (`native-image-configure-launcher`)
+is not shipped with graalvm releases, it has to be built. This project includes two binaries of the tool, one for macOS
+and the other for Linux, under [graalvm/bin](./graalvm/bin). During CI workflows that run on PR to `main` branch, the
+app is executed with the `native-image-agent` producing different sets of configurations for different combinations of
+input options and parameters. This is done in
+script [.github/scripts/create-native-image-build-config.sh](.github/scripts/create-native-image-build-config.sh). Then
+the generated configurations are merged into the project's sources by another
+script, [.github/scripts/merge-native-image-build-config.sh](.github/scripts/merge-native-image-build-config.sh).
 Finally, a new commit is made to the PR branch with the updated configuration.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The tool supports both SSH and HTTPS protocols for cloning projects, SSH being t
 
 #### SSH
 
-There are two requirements for cloning via SSH that apply to both public and private groups:
+There are three requirements for cloning via SSH that apply to both public and private groups:
 
 1. A known hosts file containing and entry for the GitLab server must exist in the default
    location (`${HOME}/.ssh/known_hosts`). This entry looks something like
@@ -82,6 +82,10 @@ There are two requirements for cloning via SSH that apply to both public and pri
    an entry for the GitLab server in the ssh client configuration that points to the correct key.
    See [GitLab documentation on configuring SSH access](https://docs.gitlab.com/ee/ssh/) for more information on how to
    set this up
+3. The private key must be in the PEM format, the keyfile needs to start with the line:
+   `-----BEGIN RSA PRIVATE KEY-----`
+   _Note: Support for the OpenSSH key format will be available once a native binary can be produced with a Java15
+   GraalVM native-image. See Issue #16 to track progress of this_
 
 Cloning via HTTPS (cli option `--clone-protocol=HTTPS`) does not require any setup for public groups. For private
 groups, the username needs to be provided (cli option `--https-username=<USERNAME>`). The GitLab token specified on the

--- a/src/main/java/gitlab/clone/GitlabClient.java
+++ b/src/main/java/gitlab/clone/GitlabClient.java
@@ -1,5 +1,9 @@
 package gitlab.clone;
 
+import static gitlab.clone.GitlabClient.H_PRIVATE_TOKEN;
+
+import java.util.List;
+
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.annotation.Get;
 import io.micronaut.http.annotation.Header;
@@ -8,10 +12,6 @@ import io.micronaut.http.annotation.QueryValue;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.retry.annotation.Retryable;
 import io.reactivex.Flowable;
-
-import java.util.List;
-
-import static gitlab.clone.GitlabClient.H_PRIVATE_TOKEN;
 
 @Retryable
 @Client("${gitlab.url}/api/v4")
@@ -22,6 +22,14 @@ public interface GitlabClient {
     @Get("/groups{?search,per_page,all_available,page}")
     Flowable<HttpResponse<List<GitlabGroup>>> searchGroups(
             @QueryValue String search,
+            @QueryValue(value = "all_available") boolean allAvailable,
+            @QueryValue(value = "per_page") int perPage,
+            @QueryValue int page
+    );
+
+    @Get("/groups/{id}/subgroups{?all_available,per_page,page}")
+    Flowable<HttpResponse<List<GitlabGroup>>> groupSubGroups(
+            @PathVariable String id,
             @QueryValue(value = "all_available") boolean allAvailable,
             @QueryValue(value = "per_page") int perPage,
             @QueryValue int page

--- a/src/main/java/gitlab/clone/GitlabVersion.java
+++ b/src/main/java/gitlab/clone/GitlabVersion.java
@@ -1,18 +1,42 @@
 package gitlab.clone;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.core.util.VersionUtil;
 import io.micronaut.core.annotation.Introspected;
 import lombok.AllArgsConstructor;
-import lombok.ToString;
+import lombok.Data;
 
 @Introspected
+@Data
 @AllArgsConstructor
-@ToString
 public class GitlabVersion {
     String version;
     String revision;
 
     @JsonCreator
     public GitlabVersion() {
+    }
+
+    public boolean isBefore(String lowerBound) {
+        return compare(lowerBound) < 0;
+    }
+
+    int compare(String lowerBound) {
+        final Version lowerBoundVersion = parse(lowerBound);
+        final Version thisVersion = parse(version);
+
+        return thisVersion.compareTo(lowerBoundVersion);
+    }
+
+    static Version parse(String text) {
+        final String versionText;
+        if (text.contains("-")) {
+            final String[] mainSplit = text.split("-");
+            versionText = mainSplit[0];
+        } else {
+            versionText = text;
+        }
+        return VersionUtil.parseVersion(versionText, null, null);
     }
 }

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -17,6 +17,7 @@ module gitlab.clone {
     // requires org.eclipse.jgit.ssh.jsch;
     requires jsch;
     requires io.micronaut.core;
+    requires org.reactivestreams;
 
     exports gitlab.clone;
 }

--- a/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/reflect-config.json
@@ -310,6 +310,12 @@
   "allDeclaredConstructors":true
 },
 {
+  "name":"gitlab.clone.GitlabVersion",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
   "name":"io.micronaut.aop.Interceptor[]"
 },
 {
@@ -522,6 +528,21 @@
 {
   "name":"io.micronaut.http.hateoas.$VndError$IntrospectionRef",
   "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"io.micronaut.http.hateoas.AbstractResource",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true
+},
+{
+  "name":"io.micronaut.http.hateoas.JsonError",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"io.micronaut.http.hateoas.Resource",
+  "allDeclaredMethods":true
 },
 {
   "name":"io.micronaut.http.netty.channel.$DefaultEventLoopGroupConfigurationDefinitionClass",

--- a/src/test/java/gitlab/clone/GitlabClientWithTokenTest.java
+++ b/src/test/java/gitlab/clone/GitlabClientWithTokenTest.java
@@ -49,6 +49,32 @@ class GitlabClientWithTokenTest {
     }
 
     @Test
+    void groupSubGroups_privateGroup() {
+        final Flowable<HttpResponse<List<GitlabGroup>>> groups = client.groupSubGroups(PRIVATE_GROUP_NAME, true, 10, 1);
+
+        final Iterable<HttpResponse<List<GitlabGroup>>> iterable = groups.blockingIterable();
+        assertThat(iterable).hasSize(1);
+        final HttpResponse<List<GitlabGroup>> response = iterable.iterator().next();
+        assertThat(response.getStatus().getCode()).isEqualTo(HttpStatus.OK.getCode());
+        assertThat(response.getBody()).isNotEmpty();
+        assertThat(response.getBody().get()).hasSize(1)
+                                            .allSatisfy(group -> assertThat(group.getFullPath()).contains(PRIVATE_GROUP_NAME));
+    }
+
+    @Test
+    void groupSubGroups_publicGroup() {
+        final Flowable<HttpResponse<List<GitlabGroup>>> groups = client.groupSubGroups(PUBLIC_GROUP_ID, true, 10, 1);
+
+        final Iterable<HttpResponse<List<GitlabGroup>>> iterable = groups.blockingIterable();
+        assertThat(iterable).hasSize(1);
+        final HttpResponse<List<GitlabGroup>> response = iterable.iterator().next();
+        assertThat(response.getStatus().getCode()).isEqualTo(HttpStatus.OK.getCode());
+        assertThat(response.getBody()).isNotEmpty();
+        assertThat(response.getBody().get()).hasSize(2)
+                                            .allSatisfy(group -> assertThat(group.getFullPath()).contains(PUBLIC_GROUP_NAME));
+    }
+
+    @Test
     void groupDescendants_privateGroup() {
         final Flowable<HttpResponse<List<GitlabGroup>>> groups = client.groupDescendants(PRIVATE_GROUP_ID, true, 10, 1);
 
@@ -76,7 +102,7 @@ class GitlabClientWithTokenTest {
 
     @Test
     void groupProjects_publicGroup() {
-        final Flowable<HttpResponse<List<GitlabProject>>> groups = client.groupProjects(PUBLIC_GROUP_ID, true, 10, 0);
+        final Flowable<HttpResponse<List<GitlabProject>>> groups = client.groupProjects(PUBLIC_GROUP_ID, true, 10, 1);
 
         final Iterable<HttpResponse<List<GitlabProject>>> iterable = groups.blockingIterable();
         assertThat(iterable).hasSize(1);
@@ -89,7 +115,7 @@ class GitlabClientWithTokenTest {
 
     @Test
     void groupProjects_privateGroup() {
-        final Flowable<HttpResponse<List<GitlabProject>>> groups = client.groupProjects(PRIVATE_GROUP_ID, true, 10, 0);
+        final Flowable<HttpResponse<List<GitlabProject>>> groups = client.groupProjects(PRIVATE_GROUP_ID, true, 10, 1);
 
         final Iterable<HttpResponse<List<GitlabProject>>> iterable = groups.blockingIterable();
         assertThat(iterable).hasSize(1);
@@ -98,5 +124,13 @@ class GitlabClientWithTokenTest {
         assertThat(response.getBody()).isNotEmpty();
         assertThat(response.getBody().get()).hasSize(1)
                                             .allSatisfy(project -> assertThat(project.getName()).isEqualTo("a-private-project"));
+    }
+
+    @Test
+    void getVersion() {
+        final GitlabVersion version = client.version();
+
+        assertThat(version).isNotNull();
+        assertThat(version.getVersion()).isNotNull();
     }
 }

--- a/src/test/java/gitlab/clone/GitlabClientWithoutTokenTest.java
+++ b/src/test/java/gitlab/clone/GitlabClientWithoutTokenTest.java
@@ -29,7 +29,7 @@ class GitlabClientWithoutTokenTest {
     private GitlabClient client;
 
     @Test
-    void searchGroups_privateGroup() {
+    void searchGroups_privateGroup_withoutToken() {
         final Flowable<HttpResponse<List<GitlabGroup>>> groups = client.searchGroups(PRIVATE_GROUP_NAME, true, 10, 1);
 
         final Iterable<HttpResponse<List<GitlabGroup>>> iterable = groups.blockingIterable();
@@ -95,5 +95,12 @@ class GitlabClientWithoutTokenTest {
         final HttpClientException e = assertThrows(HttpClientException.class, groups::blockingFirst);
 
         assertThat(e).hasMessage("404 Group Not Found");
+    }
+
+    @Test
+    void getVersion() {
+        final HttpClientResponseException responseException = assertThrows(HttpClientResponseException.class, () -> client.version());
+
+        assertThat(responseException.getStatus().getCode()).isEqualTo(401);
     }
 }

--- a/src/test/java/gitlab/clone/GitlabCloneCommandBase.java
+++ b/src/test/java/gitlab/clone/GitlabCloneCommandBase.java
@@ -1,9 +1,6 @@
 package gitlab.clone;
 
-import io.micronaut.context.ApplicationContext;
-import io.micronaut.context.env.Environment;
-import org.assertj.core.api.AbstractFileAssert;
-import org.assertj.core.api.AbstractStringAssert;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -11,9 +8,13 @@ import java.io.PrintStream;
 import java.nio.file.Path;
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.env.Environment;
+import org.assertj.core.api.AbstractFileAssert;
+import org.assertj.core.api.AbstractStringAssert;
 
 public class GitlabCloneCommandBase {
+
     public static final String PUBLIC_GROUP_NAME = "gitlab-clone-example";
     public static final String PRIVATE_GROUP_NAME = "gitlab-clone-example-private";
     public static final int TEST_OUTPUT_ARRAY_SIZE = 4096000;

--- a/src/test/java/gitlab/clone/GitlabServiceTest.java
+++ b/src/test/java/gitlab/clone/GitlabServiceTest.java
@@ -1,9 +1,5 @@
 package gitlab.clone;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import javax.inject.Inject;
-
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import io.reactivex.Flowable;
 import io.vavr.control.Either;
@@ -11,25 +7,44 @@ import org.assertj.core.api.Assertions;
 import org.assertj.vavr.api.VavrAssertions;
 import org.junit.jupiter.api.Test;
 
+import javax.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 @MicronautTest
 class GitlabServiceTest {
 
-    public static final String GITLAB_GROUP = "gitlab-clone-example";
+    public static final String GITLAB_GROUP_NAME = "gitlab-clone-example";
+    public static final String GITLAB_GROUP_ID = "11961707";
 
     @Inject
     private GitlabService service;
 
     @Test
     void findGroupByName() {
-        final Either<String, GitlabGroup> maybeGroup = service.findGroupByName(GITLAB_GROUP);
+        final Either<String, GitlabGroup> maybeGroup = service.findGroupByName(GITLAB_GROUP_NAME);
 
         VavrAssertions.assertThat(maybeGroup).isRight();
-        Assertions.assertThat(maybeGroup.get().getName()).isEqualTo(GITLAB_GROUP);
+        Assertions.assertThat(maybeGroup.get().getName()).isEqualTo(GITLAB_GROUP_NAME);
+    }
+
+    @Test
+    void getDescendantGroups() {
+        final Flowable<GitlabGroup> descendantGroups = service.getDescendantGroups(GITLAB_GROUP_ID);
+
+        assertThat(descendantGroups.blockingIterable()).hasSize(3);
+    }
+
+    @Test
+    void getSubGroupsRecursively() {
+        final Flowable<GitlabGroup> descendantGroups = service.getSubGroupsRecursively(GITLAB_GROUP_ID);
+
+        assertThat(descendantGroups.blockingIterable()).hasSize(3);
     }
 
     @Test
     void getGitlabGroupProjects() {
-        final GitlabGroup group = service.findGroupByName(GITLAB_GROUP).get();
+        final GitlabGroup group = service.findGroupByName(GITLAB_GROUP_NAME).get();
         final Flowable<GitlabProject> projects = service.getGitlabGroupProjects(group);
 
         assertThat(projects.blockingIterable()).hasSize(3);

--- a/src/test/java/gitlab/clone/GitlabVersionTest.java
+++ b/src/test/java/gitlab/clone/GitlabVersionTest.java
@@ -1,0 +1,131 @@
+package gitlab.clone;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class GitlabVersionTest {
+
+    @Test
+    void versionIsBefore_patchVersion() {
+        final GitlabVersion version = new GitlabVersion("1.2.3", "");
+
+        assertThat(version.isBefore("2"))
+                .as("Check version is before")
+                .isTrue();
+        assertThat(version.isBefore("1.3"))
+                .as("Check version is before")
+                .isTrue();
+        assertThat(version.isBefore("2.1"))
+                .as("Check version is before")
+                .isTrue();
+        assertThat(version.isBefore("1.2.4"))
+                .as("Check version is before")
+                .isTrue();
+        assertThat(version.isBefore("2.1.0"))
+                .as("Check version is before")
+                .isTrue();
+    }
+
+    @Test
+    void versionIsNotBefore_patchVersion() {
+        final GitlabVersion version = new GitlabVersion("1.2.3", "");
+
+        assertThat(version.isBefore("1"))
+                .as("Check version is not before")
+                .isFalse();
+        assertThat(version.isBefore("1.2"))
+                .as("Check version is not before")
+                .isFalse();
+        assertThat(version.isBefore("1.2.0"))
+                .as("Check version is not before")
+                .isFalse();
+        assertThat(version.isBefore("1.2.2"))
+                .as("Check version is not before")
+                .isFalse();
+        assertThat(version.isBefore("1.2.3"))
+                .as("Check version is not before")
+                .isFalse();
+    }
+
+    @Test
+    void versionIsBefore_minorVersion() {
+        final GitlabVersion version = new GitlabVersion("1.2", "");
+
+        assertThat(version.isBefore("2"))
+                .as("Check version is before")
+                .isTrue();
+        assertThat(version.isBefore("1.2.1"))
+                .as("Check version is before")
+                .isTrue();
+        assertThat(version.isBefore("1.3"))
+                .as("Check version is before")
+                .isTrue();
+        assertThat(version.isBefore("2.1"))
+                .as("Check version is before")
+                .isTrue();
+        assertThat(version.isBefore("2.1.0"))
+                .as("Check version is before")
+                .isTrue();
+    }
+
+    @Test
+    void versionIsNotBefore_minorVersion() {
+        final GitlabVersion version = new GitlabVersion("1.2", "");
+
+        assertThat(version.isBefore("1"))
+                .as("Check version is not before")
+                .isFalse();
+        assertThat(version.isBefore("1.2"))
+                .as("Check version is not before")
+                .isFalse();
+        assertThat(version.isBefore("1.2.0"))
+                .as("Check version is not before")
+                .isFalse();
+        assertThat(version.isBefore("1.2.0"))
+                .as("Check version is not before")
+                .isFalse();
+    }
+
+    @Test
+    void versionIsBefore_majorVersion() {
+        final GitlabVersion version = new GitlabVersion("1", "");
+
+        assertThat(version.isBefore("1.1"))
+                .as("Check version is before")
+                .isTrue();
+        assertThat(version.isBefore("2"))
+                .as("Check version is before")
+                .isTrue();
+        assertThat(version.isBefore("2.0"))
+                .as("Check version is before")
+                .isTrue();
+        assertThat(version.isBefore("2.0.0"))
+                .as("Check version is before")
+                .isTrue();
+    }
+
+    @Test
+    void versionIsNotBefore_majorVersion() {
+        final GitlabVersion version = new GitlabVersion("1", "");
+
+        assertThat(version.isBefore("0"))
+                .as("Check version is not before")
+                .isFalse();
+        assertThat(version.isBefore("1"))
+                .as("Check version is not before")
+                .isFalse();
+        assertThat(version.isBefore("1.0"))
+                .as("Check version is not before")
+                .isFalse();
+        assertThat(version.isBefore("0.1"))
+                .as("Check version is not before")
+                .isFalse();
+        assertThat(version.isBefore("0.0.1"))
+                .as("Check version is not before")
+                .isFalse();
+        assertThat(version.isBefore("1.0.0"))
+                .as("Check version is not before")
+                .isFalse();
+    }
+}


### PR DESCRIPTION
This PR implements two new GitLab APIs:
1. get the gitlab version;
2. fetch a group's sub-groups.

With these two new APIs the GitLab service can either get all the groups sub-groups via the group's descendant API or using the group's sub-groups API. The decision is made based on the version of GitLab supporting the group descendant API (included in 13.5).

Fixes #17 