### PR TITLE
Implement group search modes

### DIFF
--- a/.github/scripts/create-native-image-build-config.sh
+++ b/.github/scripts/create-native-image-build-config.sh
@@ -55,3 +55,11 @@ cmd "${native_image_config_dir}/${local_path}" -x -r gitlab-clone-example-privat
 local_path="${test_clones_dir}/public-with-token-https-with-submodules-very-verbose"
 say "Asking to clone a private group using a token, via https, with submodules"
 cmd "${native_image_config_dir}/${local_path}" -x -r -c HTTPS -u devex-bot gitlab-clone-example-private "${local_path}"
+
+local_path="${test_clones_dir}/public-by-id-with-token-very-verbose"
+say "Asking to clone a public group by id using a token, via https, with submodules"
+cmd "${native_image_config_dir}/${local_path}" -x -m id -r -c HTTPS -u devex-bot 11961707 "${local_path}"
+
+local_path="${test_clones_dir}/public-sub-group-by-full-path-with-token-very-verbose"
+say "Asking to clone a public subgroup by full path using a token, via https, with submodules"
+cmd "${native_image_config_dir}/${local_path}" -x -m full_path -r -c HTTPS -u devex-bot gitlab-clone-example/sub-group-2/sub-group-3 "${local_path}"

--- a/.github/scripts/run-native-binary.sh
+++ b/.github/scripts/run-native-binary.sh
@@ -15,11 +15,11 @@ build/native-image/application -h
 
 local_path="ssh-no-submodules"
 say "Asking to clone a group, via ssh, without submodules"
-build/native-image/application gitlab-clone-example -x "${local_path}"
+build/native-image/application -x gitlab-clone-example "${local_path}"
 [[ ! -f "${local_path}/gitlab-clone-example/a-project/some-project-sub-module/README.md" ]]
 
 say "Asking to clone the same group, via ssh, with submodules (effectively only initializing submodules)"
-build/native-image/application gitlab-clone-example -x -r "${local_path}"
+build/native-image/application -x -r gitlab-clone-example "${local_path}"
 [[ -f  "${local_path}/gitlab-clone-example/a-project/some-project-sub-module/README.md" ]]
 cd "${local_path}/gitlab-clone-example/a-project"
 [[ "$(git remote -v | head -n 1)" == *"git@"* ]]
@@ -27,7 +27,7 @@ cd -
 
 local_path="ssh-with-submodules"
 say "Asking to clone group, via ssh, with submodules"
-build/native-image/application gitlab-clone-example -x -r "${local_path}"
+build/native-image/application -x -r gitlab-clone-example "${local_path}"
 [[ -f  "${local_path}/gitlab-clone-example/a-project/some-project-sub-module/README.md" ]]
 cd "${local_path}/gitlab-clone-example/a-project"
 [[ "$(git remote -v | head -n 1)" == *"git@"* ]]
@@ -35,8 +35,22 @@ cd -
 
 local_path="https-with-submodules"
 say "Asking to clone group, via https, with submodules"
-build/native-image/application gitlab-clone-example -x -r -c HTTPS -u devex-bot "${local_path}"
+build/native-image/application -x -r -c HTTPS -u devex-bot gitlab-clone-example  "${local_path}"
 [[ -f  "${local_path}/gitlab-clone-example/a-project/some-project-sub-module/README.md" ]]
 cd "${local_path}/gitlab-clone-example/a-project"
 [[ "$(git remote -v | head -n 1)" == *"https://"* ]]
+cd -
+
+local_path="https-by-id"
+say "Asking to clone group by id"
+build/native-image/application -x -r -c HTTPS -u devex-bot -m id 11961707 "${local_path}"
+[[ -f  "${local_path}/gitlab-clone-example/a-project/some-project-sub-module/README.md" ]]
+cd "${local_path}/gitlab-clone-example/a-project"
+[[ "$(git remote -v | head -n 1)" == *"https://"* ]]
+cd -
+
+local_path="ssh-by-full-path"
+say "Asking to clone group by full path"
+build/native-image/application -x -m full_path gitlab-clone-example/sub-group-2/sub-group-3 "${local_path}"
+[[ -f  "${local_path}/gitlab-clone-example/sub-group-2/sub-group-3/another-project/README.md" ]]
 cd -

--- a/README.md
+++ b/README.md
@@ -30,6 +30,55 @@ For cloning public groups no token is needed, for private groups a token with sc
 GitLab's [Limiting scopes of a personal access token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#limiting-scopes-of-a-personal-access-token)
 for more details on token scopes.
 
+### Public groups
+
+Cloning public groups does not require a gitlab token, however without a token it won't be possible to detect the version of GitLab server.
+That always results in an error message, and in defaulting to using the `group_descendants` API, which is not available in versions of GitLab pre `13.5`.
+
+**Cloning a public group by name, to the current directory, using SSH protocol**
+```bash
+gitlab-clone open-source-devex
+```
+**Cloning a public group by name, to the current directory, initializing git submodules, using SSH protocol**
+```bash
+gitlab-clone --recurse-submodules open-source-devex
+```
+**Cloning a group by name, to a specified location, using SSH protocol**
+```bash
+gitlab-clone open-source-devex ~/some-path-on-my-home
+```
+**Cloning a public group by id, to the current directory, using SSH protocol**
+```bash
+gitlab-clone --search-mode id 2150497
+```
+**Cloning a public group by path, to the current directory, using SSH protocol**
+```bash
+gitlab-clone --search-mode full_path open-source-devex/terraform-modules/aws
+```
+**Cloning a public group by name, to the current directory, using HTTPS protocol**
+```bash
+gitlab-clone --clone-protocol https open-source-devex
+```
+
+### Private groups and self-hosted GitLab servers
+
+Cloning private groups requires a gitlab token.
+Cloning from GitLab servers other than [gitlab.com](https://gitlab.com) requires the url for the server.
+
+**Cloning a private group by name, to the current directory, using SSH protocol**
+```bash
+GITLAB_TOKEN="..." gitlab-clone "some private group"
+```
+**Cloning a private group by name, to the current directory, using HTTPS protocol**
+```bash
+GITLAB_TOKEN="..." gitlab-clone --clone-protocol https --https-username miguelaferreira "some private group"
+```
+**Cloning a private group by name, to the current directory, using SSH protocol, from a self-hosted GitLab server**
+```bash
+GITLAB_URL="https://gitlab.acme.com" GITLAB_TOKEN="..." gitlab-clone "some private group"
+```
+
+### Full usage description
 ```
 $ gitlab-clone -h
 Usage:
@@ -38,13 +87,14 @@ Clone an entire GitLab group with all sub-groups and repositories.
 While cloning initialize project git sub-modules (may require two runs due to ordering of projects).
 When a project is already cloned, tries to initialize git sub-modules.
 
-gitlab-clone [-hrvVx] [--debug] [--trace] [-u[=<httpsUsername>]] [-c=<cloneProtocol>] GROUP PATH
+gitlab-clone [-hrvVx] [--debug] [--trace] [-u[=<httpsUsername>]] [-c=<cloneProtocol>] [-m=<searchMode>] GROUP PATH
 
 GitLab configuration:
 
 The GitLab URL and private token are read from the environment, using GITLAB_URL and GITLAB_TOKEN variables.
 GITLAB_URL defaults to 'https://gitlab.com'.
-The GitLab token is used for both querying the GitLab API and discover the group to clone and as the password for cloning using HTTPS.
+The GitLab token is used for both querying the GitLab API and discover the group to clone and as the password for
+cloning using HTTPS.
 No token is needed for public groups and repositories.
 
 Parameters:
@@ -54,15 +104,22 @@ Parameters:
 Options:
   -h, --help                 Show this help message and exit.
   -V, --version              Print version information and exit.
-  -r, --recurse-submodules   Initialize project submodules. If projects are already cloned try and initialize sub-modules anyway.
+  -r, --recurse-submodules   Initialize project submodules. If projects are already cloned try and initialize
+                               sub-modules anyway.
   -c, --clone-protocol=<cloneProtocol>
                              Chose the transport protocol used clone the project repositories. Valid values: SSH, HTTPS.
+  -m, --search-mode=<searchMode>
+                             Chose how the group is searched for. Groups can be searched by name or full path. Valid
+                               values: NAME, FULL_PATH, ID.
   -u, --https-username[=<httpsUsername>]
-                             The username to authenticate with when the HTTPS clone protocol is selected. This option is required when cloning private groups, in which case the GitLab token will be used as the password.
+                             The username to authenticate with when the HTTPS clone protocol is selected. This option
+                               is required when cloning private groups, in which case the GitLab token will be used as
+                               the password.
   -v, --verbose              Print out extra information about what the tool is doing.
   -x, --very-verbose         Print out even more information about what the tool is doing.
       --debug                Sets all loggers to DEBUG level.
-      --trace                Sets all loggers to TRACE level. WARNING: this setting will leak the GitLab token or password to the logs, use with caution.
+      --trace                Sets all loggers to TRACE level. WARNING: this setting will leak the GitLab token or
+                               password to the logs, use with caution.
 
 Copyright(c) 2021 - Miguel Ferreira - GitHub/GitLab: @miguelaferreira
 ```

--- a/src/main/java/gitlab/clone/GitlabClient.java
+++ b/src/main/java/gitlab/clone/GitlabClient.java
@@ -1,9 +1,5 @@
 package gitlab.clone;
 
-import static gitlab.clone.GitlabClient.H_PRIVATE_TOKEN;
-
-import java.util.List;
-
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.annotation.Get;
 import io.micronaut.http.annotation.Header;
@@ -12,6 +8,11 @@ import io.micronaut.http.annotation.QueryValue;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.retry.annotation.Retryable;
 import io.reactivex.Flowable;
+
+import java.util.List;
+import java.util.Optional;
+
+import static gitlab.clone.GitlabClient.H_PRIVATE_TOKEN;
 
 @Retryable
 @Client("${gitlab.url}/api/v4")
@@ -26,6 +27,9 @@ public interface GitlabClient {
             @QueryValue(value = "per_page") int perPage,
             @QueryValue int page
     );
+
+    @Get("/groups/{id}")
+    Optional<GitlabGroup> getGroup(@PathVariable String id);
 
     @Get("/groups/{id}/subgroups{?all_available,per_page,page}")
     Flowable<HttpResponse<List<GitlabGroup>>> groupSubGroups(

--- a/src/main/java/gitlab/clone/GitlabCloneCommand.java
+++ b/src/main/java/gitlab/clone/GitlabCloneCommand.java
@@ -159,7 +159,7 @@ public class GitlabCloneCommand implements Runnable {
 
         final GitlabGroup group = maybeGroup.get();
         log.debug("Found group = {}", group);
-        final Flowable<Tuple2<GitlabProject, Either<String, Git>>> clonedProjects =
+        final Flowable<Tuple2<GitlabProject, Either<Throwable, Git>>> clonedProjects =
                 gitlabService.getGitlabGroupProjects(group)
                              .map(project -> Tuple.of(project, project))
                              .map(tuple -> tuple.map2(
@@ -172,9 +172,9 @@ public class GitlabCloneCommand implements Runnable {
         clonedProjects.blockingIterable()
                       .forEach(tuple -> {
                           final GitlabProject project = tuple._1;
-                          final Either<String, Git> gitRepoOrError = tuple._2;
+                          final Either<Throwable, Git> gitRepoOrError = tuple._2;
                           if (gitRepoOrError.isLeft()) {
-                              log.warn(gitRepoOrError.getLeft());
+                              log.warn("Git operation failed", gitRepoOrError.getLeft());
                           } else {
                               log.info("Project '{}' updated.", project.getNameWithNamespace());
                           }

--- a/src/main/java/gitlab/clone/GitlabCloneCommand.java
+++ b/src/main/java/gitlab/clone/GitlabCloneCommand.java
@@ -117,7 +117,7 @@ public class GitlabCloneCommand implements Runnable {
             paramLabel = "GROUP",
             description = "The GitLab group to clone."
     )
-    private String gitlabGroupName;
+    private String gitlabGroup;
 
     @CommandLine.Parameters(
             index = "1",
@@ -167,15 +167,17 @@ public class GitlabCloneCommand implements Runnable {
     }
 
     private void cloneGroup() {
-        log.info("Cloning group '{}'", gitlabGroupName);
-        final Either<String, GitlabGroup> maybeGroup = gitlabService.findGroupBy(gitlabGroupName, searchMode);
+        log.info("Cloning group '{}'", gitlabGroup);
+
+        final Either<String, GitlabGroup> maybeGroup = gitlabService.findGroupBy(gitlabGroup, searchMode);
         if (maybeGroup.isLeft()) {
-            log.info("Could not find group '{}': {}", gitlabGroupName, maybeGroup.getLeft());
+            log.info("Could not find group '{}': {}", gitlabGroup, maybeGroup.getLeft());
             return;
         }
 
         final GitlabGroup group = maybeGroup.get();
         log.debug("Found group = {}", group);
+
         final Flowable<Tuple2<GitlabProject, Either<Throwable, Git>>> clonedProjects =
                 gitlabService.getGitlabGroupProjects(group)
                              .map(project -> Tuple.of(project, project))

--- a/src/main/java/gitlab/clone/GitlabGroupSearchMode.java
+++ b/src/main/java/gitlab/clone/GitlabGroupSearchMode.java
@@ -1,0 +1,27 @@
+package gitlab.clone;
+
+import java.util.function.Predicate;
+
+public enum GitlabGroupSearchMode {
+    NAME, FULL_PATH;
+
+    public String textualQualifier() {
+        switch (this) {
+            case NAME:
+                return "named";
+            case FULL_PATH:
+                return "with full path";
+        }
+        throw new IllegalArgumentException("There is no qualifier defined for " + this);
+    }
+
+    public Predicate<GitlabGroup> groupPredicate(String search) {
+        switch (this) {
+            case NAME:
+                return group -> group.getName().equalsIgnoreCase(search);
+            case FULL_PATH:
+                return group -> group.getFullPath().equalsIgnoreCase(search);
+        }
+        throw new IllegalArgumentException("There is no predicate defined for " + this);
+    }
+}

--- a/src/main/java/gitlab/clone/GitlabGroupSearchMode.java
+++ b/src/main/java/gitlab/clone/GitlabGroupSearchMode.java
@@ -3,7 +3,7 @@ package gitlab.clone;
 import java.util.function.Predicate;
 
 public enum GitlabGroupSearchMode {
-    NAME, FULL_PATH;
+    NAME, FULL_PATH, ID;
 
     public String textualQualifier() {
         switch (this) {
@@ -11,6 +11,8 @@ public enum GitlabGroupSearchMode {
                 return "named";
             case FULL_PATH:
                 return "with full path";
+            case ID:
+                return "identified by";
         }
         throw new IllegalArgumentException("There is no qualifier defined for " + this);
     }
@@ -21,6 +23,8 @@ public enum GitlabGroupSearchMode {
                 return group -> group.getName().equalsIgnoreCase(search);
             case FULL_PATH:
                 return group -> group.getFullPath().equalsIgnoreCase(search);
+            case ID:
+                return group -> group.getId().equalsIgnoreCase(search);
         }
         throw new IllegalArgumentException("There is no predicate defined for " + this);
     }

--- a/src/test/java/gitlab/clone/GitServiceTest.java
+++ b/src/test/java/gitlab/clone/GitServiceTest.java
@@ -139,7 +139,7 @@ class GitServiceTest {
                              .build()
         );
 
-        final Stream<Either<String, Git>> result = flowableToStream(projects.map(project -> gitService.cloneProject(project, cloneDirectoryPath)));
+        final Stream<Either<Throwable, Git>> result = flowableToStream(projects.map(project -> gitService.cloneProject(project, cloneDirectoryPath)));
         final List<Git> gits = result.filter(Either::isRight).map(Either::get).toJavaList();
 
         assertThat(gits).hasSize(3);
@@ -178,8 +178,8 @@ class GitServiceTest {
                                                           .allSatisfy(this::submoduleIsInitialized);
 
         // clone entire group
-        final Stream<Either<String, Git>> result = flowableToStream(projects.map(project -> gitService.cloneOrInitSubmodulesProject(project, cloneDirectoryPath)));
-        final List<String> errors = result.filter(Either::isLeft).map(Either::getLeft).toJavaList();
+        final Stream<Either<Throwable, Git>> result = flowableToStream(projects.map(project -> gitService.cloneOrInitSubmodulesProject(project, cloneDirectoryPath)));
+        final List<Throwable> errors = result.filter(Either::isLeft).map(Either::getLeft).toJavaList();
         final List<Git> gits = result.filter(Either::isRight).map(Either::get).toJavaList();
         final java.util.stream.Stream<Map<String, SubmoduleStatus>> submoduleStatus = gits.stream().map(git -> {
             try {
@@ -226,8 +226,8 @@ class GitServiceTest {
                                                           .allSatisfy(this::submoduleIsUninitialized);
 
         // clone entire group
-        final Stream<Either<String, Git>> result = flowableToStream(projects.map(project -> gitService.cloneOrInitSubmodulesProject(project, cloneDirectoryPath)));
-        final List<String> errors = result.filter(Either::isLeft).map(Either::getLeft).toJavaList();
+        final Stream<Either<Throwable, Git>> result = flowableToStream(projects.map(project -> gitService.cloneOrInitSubmodulesProject(project, cloneDirectoryPath)));
+        final List<Throwable> errors = result.filter(Either::isLeft).map(Either::getLeft).toJavaList();
         final List<Git> gits = result.filter(Either::isRight).map(Either::get).toJavaList();
         final java.util.stream.Stream<Map<String, SubmoduleStatus>> submoduleStatus = gits.stream().map(git -> {
             try {

--- a/src/test/java/gitlab/clone/GitlabClientWithTokenTest.java
+++ b/src/test/java/gitlab/clone/GitlabClientWithTokenTest.java
@@ -1,15 +1,16 @@
 package gitlab.clone;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import javax.inject.Inject;
-import java.util.List;
-
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import io.reactivex.Flowable;
 import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @MicronautTest
 class GitlabClientWithTokenTest {
@@ -33,6 +34,15 @@ class GitlabClientWithTokenTest {
         assertThat(response.getBody()).isNotEmpty();
         assertThat(response.getBody().get()).hasSize(2)
                                             .allSatisfy(group -> assertThat(group.getFullPath()).contains(PRIVATE_GROUP_NAME));
+    }
+
+    @Test
+    void getGroup_privateGroup_withoutToken() {
+        final Optional<GitlabGroup> maybeGroup = client.getGroup(PRIVATE_GROUP_ID);
+
+        assertThat(maybeGroup).isNotEmpty();
+        assertThat(maybeGroup.get().getId()).isEqualTo(PRIVATE_GROUP_ID);
+        assertThat(maybeGroup.get().getName()).isEqualTo(PRIVATE_GROUP_NAME);
     }
 
     @Test

--- a/src/test/java/gitlab/clone/GitlabClientWithoutTokenTest.java
+++ b/src/test/java/gitlab/clone/GitlabClientWithoutTokenTest.java
@@ -1,11 +1,5 @@
 package gitlab.clone;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
-import javax.inject.Inject;
-import java.util.List;
-
 import io.micronaut.context.annotation.Property;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
@@ -14,6 +8,12 @@ import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import io.reactivex.Flowable;
 import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SuppressWarnings("ResultOfMethodCallIgnored")
 @MicronautTest
@@ -99,7 +99,10 @@ class GitlabClientWithoutTokenTest {
 
     @Test
     void getVersion() {
-        final HttpClientResponseException responseException = assertThrows(HttpClientResponseException.class, () -> client.version());
+        final HttpClientResponseException responseException = assertThrows(
+                HttpClientResponseException.class,
+                () -> client.version()
+        );
 
         assertThat(responseException.getStatus().getCode()).isEqualTo(401);
     }

--- a/src/test/java/gitlab/clone/GitlabClientWithoutTokenTest.java
+++ b/src/test/java/gitlab/clone/GitlabClientWithoutTokenTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -41,6 +42,13 @@ class GitlabClientWithoutTokenTest {
     }
 
     @Test
+    void getGroup_privateGroup_withoutToken() {
+        final Optional<GitlabGroup> maybeGroup = client.getGroup(PRIVATE_GROUP_ID);
+
+        assertThat(maybeGroup).isEmpty();
+    }
+
+    @Test
     void searchGroups_publicGroup() {
         final Flowable<HttpResponse<List<GitlabGroup>>> groups = client.searchGroups(PUBLIC_GROUP_NAME, true, 10, 1);
 
@@ -51,6 +59,15 @@ class GitlabClientWithoutTokenTest {
         assertThat(response.getBody()).isNotEmpty();
         assertThat(response.getBody().get()).hasSize(4)
                                             .allSatisfy(group -> assertThat(group.getFullPath()).contains(PUBLIC_GROUP_NAME));
+    }
+
+    @Test
+    void getGroup_publicGroup_withoutToken() {
+        final Optional<GitlabGroup> maybeGroup = client.getGroup(PUBLIC_GROUP_ID);
+
+        assertThat(maybeGroup).isNotEmpty();
+        assertThat(maybeGroup.get().getId()).isEqualTo(PUBLIC_GROUP_ID);
+        assertThat(maybeGroup.get().getName()).isEqualTo(PUBLIC_GROUP_NAME);
     }
 
     @Test

--- a/src/test/java/gitlab/clone/GitlabCloneCommandBase.java
+++ b/src/test/java/gitlab/clone/GitlabCloneCommandBase.java
@@ -16,6 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class GitlabCloneCommandBase {
 
     public static final String PUBLIC_GROUP_NAME = "gitlab-clone-example";
+    public static final String PUBLIC_GROUP_ID = "11961707";
     public static final String PRIVATE_GROUP_NAME = "gitlab-clone-example-private";
     public static final int TEST_OUTPUT_ARRAY_SIZE = 4096000;
     public static final Map<String, Object> NO_TOKEN_CONTEXT_PROPERTIES = Map.of("gitlab.token", "");
@@ -54,10 +55,10 @@ public class GitlabCloneCommandBase {
                           .contains("PRIVATE-TOKEN");
     }
 
-    public AbstractStringAssert<?> assertLogsDebug(String output, String groupName) {
+    public AbstractStringAssert<?> assertLogsDebug(String output, String group, String groupPath) {
         return assertThat(output).contains("Set application loggers to DEBUG")
-                                 .contains(String.format("Cloning group '%s'", groupName))
-                                 .contains(String.format("Searching for projects in group '%s'", groupName))
+                                 .contains(String.format("Cloning group '%s'", group))
+                                 .contains(String.format("Searching for projects in group '%s'", groupPath))
                                  .contains("All done")
                                  .doesNotContain("PRIVATE-TOKEN")
                                  .doesNotContain("gitlab.clone.GitlabCloneCommand");

--- a/src/test/java/gitlab/clone/GitlabCloneCommandBase.java
+++ b/src/test/java/gitlab/clone/GitlabCloneCommandBase.java
@@ -1,6 +1,9 @@
 package gitlab.clone;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.env.Environment;
+import org.assertj.core.api.AbstractFileAssert;
+import org.assertj.core.api.AbstractStringAssert;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -8,10 +11,7 @@ import java.io.PrintStream;
 import java.nio.file.Path;
 import java.util.Map;
 
-import io.micronaut.context.ApplicationContext;
-import io.micronaut.context.env.Environment;
-import org.assertj.core.api.AbstractFileAssert;
-import org.assertj.core.api.AbstractStringAssert;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class GitlabCloneCommandBase {
 
@@ -19,6 +19,7 @@ public class GitlabCloneCommandBase {
     public static final String PRIVATE_GROUP_NAME = "gitlab-clone-example-private";
     public static final int TEST_OUTPUT_ARRAY_SIZE = 4096000;
     public static final Map<String, Object> NO_TOKEN_CONTEXT_PROPERTIES = Map.of("gitlab.token", "");
+    public static final String PUBLIC_SUB_GROUP_FULL_PATH = "gitlab-clone-example/sub-group-2/sub-group-3";
 
     public ByteArrayOutputStream redirectOutput() {
         ByteArrayOutputStream baos = new ByteArrayOutputStream(TEST_OUTPUT_ARRAY_SIZE);
@@ -56,7 +57,6 @@ public class GitlabCloneCommandBase {
     public AbstractStringAssert<?> assertLogsDebug(String output, String groupName) {
         return assertThat(output).contains("Set application loggers to DEBUG")
                                  .contains(String.format("Cloning group '%s'", groupName))
-                                 .contains(String.format("Looking for group named: %s", groupName))
                                  .contains(String.format("Searching for projects in group '%s'", groupName))
                                  .contains("All done")
                                  .doesNotContain("PRIVATE-TOKEN")
@@ -95,6 +95,12 @@ public class GitlabCloneCommandBase {
             final Path submodulePath = Path.of(cloneDirectory.getAbsolutePath(), PUBLIC_GROUP_NAME, "a-project", "some-project-sub-module");
             assertThat(submodulePath).isEmptyDirectory();
         }
+    }
+
+    public void assertCloneContentsPublicSubGroup(File cloneDirectory) {
+        final AbstractFileAssert<?> abstractFileAssert = assertThat(cloneDirectory);
+        abstractFileAssert.isDirectoryContaining(String.format("glob:**/%s", PUBLIC_GROUP_NAME))
+                          .isDirectoryRecursivelyContaining(String.format("glob:**/%s/sub-group-2/sub-group-3/another-project/README.md", PUBLIC_GROUP_NAME));
     }
 
     public void assertCloneContentsPrivateGroup(File cloneDirectory) {

--- a/src/test/java/gitlab/clone/GitlabCloneCommandWithTokenTest.java
+++ b/src/test/java/gitlab/clone/GitlabCloneCommandWithTokenTest.java
@@ -35,7 +35,7 @@ public class GitlabCloneCommandWithTokenTest extends GitlabCloneCommandBase {
             String[] args = new String[]{"-v", PUBLIC_GROUP_NAME, cloneDirectory.toPath().toString()};
             GitlabCloneCommand.execute(ctx, args);
 
-            assertLogsDebug(baos.toString(), PUBLIC_GROUP_NAME)
+            assertLogsDebug(baos.toString(), PUBLIC_GROUP_NAME, PUBLIC_GROUP_NAME)
                     .contains(String.format("Looking for group named: %s", PUBLIC_GROUP_NAME));
             assertCloneContentsPublicGroup(cloneDirectory, false);
             final Path submodulePath = Path.of(cloneDirectory.getAbsolutePath(), "gitlab-clone-example", "a-project", "some-project-sub-module");

--- a/src/test/java/gitlab/clone/GitlabCloneCommandWithTokenTest.java
+++ b/src/test/java/gitlab/clone/GitlabCloneCommandWithTokenTest.java
@@ -1,19 +1,18 @@
 package gitlab.clone;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import ch.qos.logback.core.joran.spi.JoranException;
+import io.micronaut.context.ApplicationContext;
+import org.assertj.core.api.AbstractStringAssert;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.PrintStream;
 import java.nio.file.Path;
 
-import ch.qos.logback.core.joran.spi.JoranException;
-import io.micronaut.configuration.picocli.PicocliRunner;
-import io.micronaut.context.ApplicationContext;
-import org.assertj.core.api.AbstractStringAssert;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class GitlabCloneCommandWithTokenTest extends GitlabCloneCommandBase {
 
@@ -34,9 +33,10 @@ public class GitlabCloneCommandWithTokenTest extends GitlabCloneCommandBase {
 
         try (ApplicationContext ctx = buildApplicationContext()) {
             String[] args = new String[]{"-v", PUBLIC_GROUP_NAME, cloneDirectory.toPath().toString()};
-            PicocliRunner.run(GitlabCloneCommand.class, ctx, args);
+            GitlabCloneCommand.execute(ctx, args);
 
-            assertLogsDebug(baos.toString(), PUBLIC_GROUP_NAME);
+            assertLogsDebug(baos.toString(), PUBLIC_GROUP_NAME)
+                    .contains(String.format("Looking for group named: %s", PUBLIC_GROUP_NAME));
             assertCloneContentsPublicGroup(cloneDirectory, false);
             final Path submodulePath = Path.of(cloneDirectory.getAbsolutePath(), "gitlab-clone-example", "a-project", "some-project-sub-module");
             assertThat(submodulePath).isEmptyDirectory();
@@ -49,7 +49,7 @@ public class GitlabCloneCommandWithTokenTest extends GitlabCloneCommandBase {
 
         try (ApplicationContext ctx = buildApplicationContext()) {
             String[] args = new String[]{"-x", PRIVATE_GROUP_NAME, cloneDirectory.toPath().toString()};
-            PicocliRunner.run(GitlabCloneCommand.class, ctx, args);
+            GitlabCloneCommand.execute(ctx, args);
 
             final AbstractStringAssert<?> testAssert = assertLogsTrace(baos.toString(), PRIVATE_GROUP_NAME);
             assertLogsTraceWhenGroupFound(testAssert, PRIVATE_GROUP_NAME);
@@ -64,7 +64,7 @@ public class GitlabCloneCommandWithTokenTest extends GitlabCloneCommandBase {
 
         try (ApplicationContext ctx = buildApplicationContext()) {
             String[] args = new String[]{"-x", "-r", PUBLIC_GROUP_NAME, cloneDirectory.toPath().toString()};
-            PicocliRunner.run(GitlabCloneCommand.class, ctx, args);
+            GitlabCloneCommand.execute(ctx, args);
 
             final AbstractStringAssert<?> testAssert = assertLogsTrace(baos.toString(), PUBLIC_GROUP_NAME);
             assertLogsTraceWhenGroupFound(testAssert, PUBLIC_GROUP_NAME);

--- a/src/test/java/gitlab/clone/GitlabCloneCommandWithoutTokenTest.java
+++ b/src/test/java/gitlab/clone/GitlabCloneCommandWithoutTokenTest.java
@@ -31,7 +31,7 @@ public class GitlabCloneCommandWithoutTokenTest extends GitlabCloneCommandBase {
             String[] args = new String[]{"-v", "-r", PUBLIC_GROUP_NAME, cloneDirectory.toPath().toString()};
             GitlabCloneCommand.execute(ctx, args);
 
-            assertLogsDebug(baos.toString(), PUBLIC_GROUP_NAME)
+            assertLogsDebug(baos.toString(), PUBLIC_GROUP_NAME, PUBLIC_GROUP_NAME)
                     .contains(String.format("Looking for group named: %s", PUBLIC_GROUP_NAME));
             assertCloneContentsPublicGroup(cloneDirectory, true);
         }
@@ -45,9 +45,23 @@ public class GitlabCloneCommandWithoutTokenTest extends GitlabCloneCommandBase {
             String[] args = new String[]{"-v", "-r", "-m", "full_path", PUBLIC_SUB_GROUP_FULL_PATH, cloneDirectory.toPath().toString()};
             GitlabCloneCommand.execute(ctx, args);
 
-            assertLogsDebug(baos.toString(), PUBLIC_SUB_GROUP_FULL_PATH)
+            assertLogsDebug(baos.toString(), PUBLIC_SUB_GROUP_FULL_PATH, PUBLIC_SUB_GROUP_FULL_PATH)
                     .contains(String.format("Looking for group with full path: %s", PUBLIC_SUB_GROUP_FULL_PATH));
             assertCloneContentsPublicSubGroup(cloneDirectory);
+        }
+    }
+
+    @Test
+    public void run_publicGroupById_withRecursion_verbose() {
+        ByteArrayOutputStream baos = redirectOutput();
+
+        try (ApplicationContext ctx = buildApplicationContext(NO_TOKEN_CONTEXT_PROPERTIES)) {
+            String[] args = new String[]{"-v", "-r", "-m", "id", PUBLIC_GROUP_ID, cloneDirectory.toPath().toString()};
+            GitlabCloneCommand.execute(ctx, args);
+
+            assertLogsDebug(baos.toString(), PUBLIC_GROUP_ID, PUBLIC_GROUP_NAME)
+                    .contains(String.format("Looking for group identified by: %s", PUBLIC_GROUP_ID));
+            assertCloneContentsPublicGroup(cloneDirectory, true);
         }
     }
 

--- a/src/test/java/gitlab/clone/GitlabServiceTest.java
+++ b/src/test/java/gitlab/clone/GitlabServiceTest.java
@@ -15,6 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class GitlabServiceTest {
 
     public static final String GITLAB_GROUP_NAME = "gitlab-clone-example";
+    public static final String GITLAB_GROUP_FULL_PATH = "gitlab-clone-example/sub-group-2/sub-group-3";
     public static final String GITLAB_GROUP_ID = "11961707";
 
     @Inject
@@ -22,10 +23,18 @@ class GitlabServiceTest {
 
     @Test
     void findGroupByName() {
-        final Either<String, GitlabGroup> maybeGroup = service.findGroupByName(GITLAB_GROUP_NAME);
+        final Either<String, GitlabGroup> maybeGroup = service.findGroupBy(GITLAB_GROUP_NAME, GitlabGroupSearchMode.NAME);
 
         VavrAssertions.assertThat(maybeGroup).isRight();
         Assertions.assertThat(maybeGroup.get().getName()).isEqualTo(GITLAB_GROUP_NAME);
+    }
+
+    @Test
+    void findGroupByFullPath() {
+        final Either<String, GitlabGroup> maybeGroup = service.findGroupBy(GITLAB_GROUP_FULL_PATH, GitlabGroupSearchMode.FULL_PATH);
+
+        VavrAssertions.assertThat(maybeGroup).isRight();
+        Assertions.assertThat(maybeGroup.get().getName()).isEqualTo("sub-group-3");
     }
 
     @Test
@@ -44,7 +53,7 @@ class GitlabServiceTest {
 
     @Test
     void getGitlabGroupProjects() {
-        final GitlabGroup group = service.findGroupByName(GITLAB_GROUP_NAME).get();
+        final GitlabGroup group = service.findGroupBy(GITLAB_GROUP_NAME, GitlabGroupSearchMode.NAME).get();
         final Flowable<GitlabProject> projects = service.getGitlabGroupProjects(group);
 
         assertThat(projects.blockingIterable()).hasSize(3);

--- a/src/test/java/gitlab/clone/GitlabServiceTest.java
+++ b/src/test/java/gitlab/clone/GitlabServiceTest.java
@@ -22,6 +22,14 @@ class GitlabServiceTest {
     private GitlabService service;
 
     @Test
+    void findGroupById() {
+        final Either<String, GitlabGroup> maybeGroup = service.findGroupBy(GITLAB_GROUP_ID, GitlabGroupSearchMode.ID);
+
+        VavrAssertions.assertThat(maybeGroup).isRight();
+        Assertions.assertThat(maybeGroup.get().getName()).isEqualTo(GITLAB_GROUP_NAME);
+    }
+
+    @Test
     void findGroupByName() {
         final Either<String, GitlabGroup> maybeGroup = service.findGroupBy(GITLAB_GROUP_NAME, GitlabGroupSearchMode.NAME);
 


### PR DESCRIPTION
This PR implements different group search modes. Previously groups could only be searched for by name. Now they can be searched by name (default), but also by ID or full path. The two new modes enable the cloning of sub-groups that do not have to be unique in their names.