### PR TITLE
Fix bug in gitlab service making repeated API calls

### DIFF
--- a/src/main/java/gitlab/clone/GitlabClient.java
+++ b/src/main/java/gitlab/clone/GitlabClient.java
@@ -6,6 +6,7 @@ import io.micronaut.http.annotation.Header;
 import io.micronaut.http.annotation.PathVariable;
 import io.micronaut.http.annotation.QueryValue;
 import io.micronaut.http.client.annotation.Client;
+import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import io.micronaut.retry.annotation.Retryable;
 import io.reactivex.Flowable;
 
@@ -14,7 +15,7 @@ import java.util.Optional;
 
 import static gitlab.clone.GitlabClient.H_PRIVATE_TOKEN;
 
-@Retryable
+@Retryable(excludes = HttpClientResponseException.class)
 @Client("${gitlab.url}/api/v4")
 @Header(name = H_PRIVATE_TOKEN, value = "${gitlab.token:}")
 public interface GitlabClient {


### PR DESCRIPTION
This PR fixes the way flowables are merged in GitlabService, to make sure they are subscribed to only once.